### PR TITLE
Add browser fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "browser": {
     "./lib/customUtils.js": "./browser-version/browser-specific/lib/customUtils.js",
     "./lib/persistence.js": "./browser-version/browser-specific/lib/persistence.js"
-  }
+  },
   "main": "index",
   "licence": "MIT"
 }


### PR DESCRIPTION
Putting the browser specific files into the browser field of package.json will mean nedb can just be required and built as part of a normal browserify project without any additional work - the browser specific files will be used by browserify instead of the server ones.

The spec for the browser field is here: https://gist.github.com/defunctzombie/4339901
