### PR TITLE
Upgrade async dependency to 0.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git@github.com:louischatriot/nedb.git"
   },
   "dependencies": {
-    "async": "0.2.9",
+    "async": "0.2.10",
     "underscore": "~1.4.4",
     "binary-search-tree": "0.2.3",
     "mkdirp": "~0.3.5"


### PR DESCRIPTION
Brings in caolan/async#350 to get nedb working directly with `require('nedb')` in browserify bundles
