### PR TITLE
Support browserify to automatically require the browser version

### DIFF
--- a/index-browserify.js
+++ b/index-browserify.js
@@ -1,0 +1,2 @@
+require('./browser-version/out/nedb.min.js');
+module.exports = Nedb;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "type": "git",
     "url": "git@github.com:louischatriot/nedb.git"
   },
+  "browser": "index-browserify.js",
   "dependencies": {
     "async": "0.2.10",
     "underscore": "~1.4.4",


### PR DESCRIPTION
Browserify will look for the file specified in the `browser` field of the `package.json` file and load it instead of `index.js`.
The file just requires the browser-version file and exports the global Nedb object
