### PR TITLE
fixed setAutocompactionInterval interval arg

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -155,14 +155,16 @@ Persistence.prototype.compactDatafile = function () {
  * @param {Number} interval in milliseconds, with an enforced minimum of 5 seconds
  */
 Persistence.prototype.setAutocompactionInterval = function (interval) {
-  var self = this;
+  var self = this
+    , minInterval = 5000
+    , realInterval = Math.max(interval||0, minInterval)
+    ;
 
-  if (interval < 5000) { interval = 5000; }
   this.stopAutocompaction();
 
   this.autocompactionIntervalId = setInterval(function () {
     self.compactDatafile();
-  }, interval);
+  }, realInterval);
 };
 
 


### PR DESCRIPTION
if interval is undefined, then it's bigger than 5000 - you get instant setInterval execution with 100% cpu load.

Test case in Chrome console:

```
> var interval
undefined
> (interval < 5000)
false
```
