### PR TITLE
added $first, $last, $before and $after query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It's a subset of MongoDB's API (the most used operations). The current API will 
   * <a href="#array-fields">Array fields</a>
   * <a href="#logical-operators-or-and-not-where">Logical operators $or, $and, $not, $where</a>
   * <a href="#sorting-and-paginating">Sorting and paginating</a>
+  * <a href="#browsing-through-documents">Browsing through documents using $first, $last, $before and $after</a>
 * <a href="#counting-documents">Counting documents</a>
 * <a href="#updating-documents">Updating documents</a>
 * <a href="#removing-documents">Removing documents</a>
@@ -337,7 +338,33 @@ db.find({ system: 'solar' }).sort({ planet: -1 }).exec(function (err, docs) {
 db.find({}).sort({ firstField: 1, secondField: -1 }) ...   // You understand how this works!
 ```
 
+#### Browsing through documents
 
+You can use `$first`, `$last`, `$before` and `$after` to browse through all or some of the documents like this:
+
+```
+db.find({ planet: { $first: true }}, function(err, docs) {
+  // docs is [ doc2 ]
+});
+
+db.find({ planet: { $after: 'Earth' }}, function(err, docs) {
+  // docs is [ doc3 ]
+});
+
+db.find({ planet: { $last: true }}, function(err, docs) {
+  // docs is [ doc4 ]
+});
+
+db.find({ planet: { $before: 'Nothing' }}, function(err, docs) {
+  // docs is [ doc1 ]
+});
+```
+
+These operators cannot be combined with any other operators, and they always only return a single result (or multiple results only in case there were multiple documents with equal keys).
+
+As seen in the last example, the key value does not have to exist in the database; the search will anyway give you the result preceding that key value. Please note that the searched field must be indexed. 
+
+Similar results can be achieved using `skip`, `sort` and `limit` but the difference is that these operators are much more efficient.
 
 ### Counting documents
 You can use `count` to count documents. It has the same syntax as `find`. For example:

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -250,6 +250,18 @@ Datastore.prototype.getCandidates = function (query) {
     return this.indexes[usableQueryKeys[0]].getMatching(query[usableQueryKeys[0]].$in);
   }
 
+  // For first/last/before/after match
+  usableQueryKeys = [];
+  Object.keys(query).forEach(function (k) {
+    if (query[k] && (query[k].hasOwnProperty('$first') || query[k].hasOwnProperty('$last') || query[k].hasOwnProperty('$after') || query[k].hasOwnProperty('$before'))) {
+      usableQueryKeys.push(k);
+    }
+  });
+  usableQueryKeys = _.intersection(usableQueryKeys, indexNames);
+  if (usableQueryKeys.length > 0) {
+    return this.indexes[usableQueryKeys[0]].getOrdered(query[usableQueryKeys[0]]);
+  }
+
   // For a comparison match
   usableQueryKeys = [];
   Object.keys(query).forEach(function (k) {

--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -257,6 +257,24 @@ Index.prototype.getMatching = function (value) {
   }
 };
 
+/**
+ * Gets all documents whose key follows right after a specific
+ * previous key, or the first document in the index, sorted by key
+ * @param {Query} query 
+ * @return {Array of documents}
+ */
+Index.prototype.getOrdered = function (query) {
+  if( query.hasOwnProperty('$first') )
+    return this.tree.search(this.tree.getMinKey());
+  else if( query.hasOwnProperty('$last') )
+    return this.tree.search(this.tree.getMaxKey());
+  else if( query.hasOwnProperty('$before') )
+    return this.tree.searchBefore(query.$before);
+  else if( query.hasOwnProperty('$after') )
+    return this.tree.searchAfter(query.$after);
+  else
+    return [];
+};
 
 /**
  * Get all documents in index whose key is between bounds are they are defined by query

--- a/lib/model.js
+++ b/lib/model.js
@@ -14,6 +14,7 @@ var dateToJSON = function () { return { $$date: this.getTime() }; }
   , comparisonFunctions = {}
   , logicalOperators = {}
   , arrayComparisonFunctions = {}
+  , orderedOperators = { $first: true, $last: true, $before: true, $after: true }
   ;
 
 
@@ -664,6 +665,10 @@ logicalOperators.$where = function (obj, fn) {
  */
 function match (obj, query) {
   var queryKeys, queryKey, queryValue, i;
+
+  for( var op in orderedOperators )
+    if( query.hasOwnProperty(op) )
+      return true; // all objects match when ordered
 
   // Primitive query against a primitive type
   // This is a bit of a hack since we construct an object with an arbitrary key only to dereference it later

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -649,6 +649,52 @@ describe('Indexes', function () {
       assert.deepEqual(idx.getMatching(['nope', 'no']), []);
     });
 
+    it('Can browse through the db with $first and $after', function() {
+      var idx = new Index({ fieldName: 'a' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, tf: 'bloup' }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, tf: 'yes' }
+        , doc5 = { a: 10, tf: 'yes' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.insert(doc5);
+
+      assert.deepEqual(idx.getOrdered({ $first: true }), [ doc2 ]);
+      assert.deepEqual(idx.getOrdered({ $after: doc2.a }), [ doc1 ]);
+      assert.deepEqual(idx.getOrdered({ $after: doc1.a }), [ doc4 ]);
+      assert.deepEqual(idx.getOrdered({ $after: doc4.a }), [ doc3 ]);
+      assert.deepEqual(idx.getOrdered({ $after: doc3.a }), [ doc5 ]);
+      assert.deepEqual(idx.getOrdered({ $after: doc5.a }), []);
+    });
+
+    it('Can browse through the db with $last and $before', function() {
+      var idx = new Index({ fieldName: 'a' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, tf: 'bloup' }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, tf: 'yes' }
+        , doc5 = { a: 10, tf: 'yes' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.insert(doc5);
+
+      assert.deepEqual(idx.getOrdered({ $last: true }), [ doc5 ]);
+      assert.deepEqual(idx.getOrdered({ $before: doc5.a }), [ doc3 ]);
+      assert.deepEqual(idx.getOrdered({ $before: doc3.a }), [ doc4 ]);
+      assert.deepEqual(idx.getOrdered({ $before: doc4.a }), [ doc1 ]);
+      assert.deepEqual(idx.getOrdered({ $before: doc1.a }), [ doc2 ]);
+      assert.deepEqual(idx.getOrdered({ $before: doc2.a }), []);
+    });
+
     it('Can get all documents whose key is between certain bounds', function () {
       var idx = new Index({ fieldName: 'a' })
         , doc1 = { a: 5, tf: 'hello' }


### PR DESCRIPTION
I need to browse through the database efficiently and using sort, skip and limit is inefficient as they make a lot of copies of documents internally while making the query.

These query parameters are slightly different than the rest in that they always only give you one result, but allow for very efficient browsing through the index. 

These can also be used to kind of "join" two NeDB databases manually by querying them in parallel and finding matching / missing documents.

Feel free to merge if you will; please note that there is a corresponding pull request to node-binary-search-tree which is required to be able to do this.

 