### PR TITLE
Inserted, updated and removed events

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -7,6 +7,7 @@ var customUtils = require('./customUtils')
   , _ = require('underscore')
   , Persistence = require('./persistence')
   , Cursor = require('./cursor')
+  , events = require('events');
   ;
 
 
@@ -21,6 +22,8 @@ var customUtils = require('./customUtils')
  */
 function Datastore (options) {
   var filename;
+
+  events.EventEmitter.call(this);
 
   // Retrocompatibility with v0.6 and before
   if (typeof options === 'string') {
@@ -61,6 +64,8 @@ function Datastore (options) {
     if (err) { throw err; }
   }); }
 }
+
+util.inherits(Datastore, events.EventEmitter);
 
 
 /**
@@ -274,7 +279,8 @@ Datastore.prototype.getCandidates = function (query) {
  * @api private Use Datastore.insert which has the same signature
  */
 Datastore.prototype._insert = function (newDoc, cb) {
-  var callback = cb || function () {}
+  var callback = cb || function () { }
+    , self = this
     ;
 
   try {
@@ -285,6 +291,7 @@ Datastore.prototype._insert = function (newDoc, cb) {
 
   this.persistence.persistNewState(util.isArray(newDoc) ? newDoc : [newDoc], function (err) {
     if (err) { return callback(err); }
+    self.emit('inserted', util.isArray(newDoc) ? newDoc : [newDoc]);
     return callback(null, newDoc);
   });
 };
@@ -490,9 +497,12 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
 	  return callback(err);
 	}
 
-	// Update the datafile
-    self.persistence.persistNewState(_.pluck(modifications, 'newDoc'), function (err) {
+    // Update the datafile
+	  var newDocs = _.pluck(modifications, 'newDoc');
+    self.persistence.persistNewState(newDocs, function (err) {
       if (err) { return callback(err); }
+      if (newDocs.length > 0)
+        self.emit('updated', newDocs);
       return callback(null, numReplaced);
     });
   }
@@ -518,6 +528,7 @@ Datastore.prototype._remove = function (query, options, cb) {
     , self = this
     , numRemoved = 0
     , multi
+    , removals = []
     , removedDocs = []
     , candidates = this.getCandidates(query)
     ;
@@ -530,14 +541,17 @@ Datastore.prototype._remove = function (query, options, cb) {
     candidates.forEach(function (d) {
       if (model.match(d, query) && (multi || numRemoved === 0)) {
         numRemoved += 1;
-        removedDocs.push({ $$deleted: true, _id: d._id });
+        removals.push({ $$deleted: true, _id: d._id });
+        removedDocs.push(d);
         self.removeFromIndexes(d);
       }
     });
   } catch (err) { return callback(err); }
 
-  self.persistence.persistNewState(removedDocs, function (err) {
+  self.persistence.persistNewState(removals, function (err) {
     if (err) { return callback(err); }
+    if (removedDocs.length > 0)
+      self.emit('removed', removedDocs);
     return callback(null, numRemoved);
   });
 };

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -14,6 +14,12 @@ var should = require('chai').should()
 describe('Database', function () {
   var d;
 
+  function remove_ids(docs){
+    docs.forEach(function(d){
+      delete d._id;
+    });
+  }
+
   beforeEach(function (done) {
     d = new Datastore({ filename: testDb });
     d.filename.should.equal(testDb);
@@ -260,7 +266,7 @@ describe('Database', function () {
         });
       });
     });
-    
+      
     /**
      * Complicated behavior here. Basically we need to test that when a user function throws an exception, it is not caught
      * in NeDB and the callback called again, transforming a user error into a NeDB error.
@@ -299,6 +305,53 @@ describe('Database', function () {
           }
         });
       });      
+    });
+    
+    describe('Events', function () {
+
+      describe('when a document is inserted', function () {
+        it('Emits the inserted event with the inserted doc', function (done) {
+          d.on('inserted', function (docs) {
+            remove_ids(docs);
+            docs.should.eql([{ a: 1 }]);            
+            done();
+          });
+          d.insert({ a: 1 }, function (err, doc) {
+            if (err) throw err;
+          });
+        });
+      });
+
+      describe('when multiple documents are inserted', function () {
+        it('Emits the inserted event with the inserted docs', function (done) {
+          d.on('inserted', function (docs) {
+            remove_ids(docs);
+            _.sortBy(docs, 'a').should.eql([{ a: 1 }, { a: 2 }]);
+            done();
+          });
+          d.insert([{ a: 1 }, { a: 2}], function (err, doc) {
+            if (err) throw err;
+          });
+        });
+      });
+
+      describe('when the insert fails', function () {
+        it('The inserted event is not emitted', function (done) {          
+          d.ensureIndex({ fieldName: 'a', unique: true }, function (err) {
+            if (err) throw err;
+          });
+          d.insert({ a: 1 }, function (err, doc) {
+            if (err) throw err;
+            d.on('inserted', function (docs) {
+              throw new Error('Inserted emitted');
+            });
+            d.insert({ a: 1 }, function (err, doc) {
+              setTimeout(done, 100);
+            });
+          });
+        });
+      });
+
     });
 
   });   // ==== End of 'Insert' ==== //
@@ -1216,6 +1269,103 @@ describe('Database', function () {
       });
     });
 
+    describe('Events', function () {
+
+      describe('when a document is updated', function () {
+        it('Emits the updated event with the updated doc', function (done) {
+          d.on('updated', function (docs) {
+            remove_ids(docs);
+            docs.should.eql([{ a: 1, b: 'bar' }]);
+            done();
+          });
+          d.insert({ a: 1, b: 'foo' }, function (err) {
+            if (err) throw err;
+            d.update({ a: 1 }, { $set: { b: 'bar' } }, {}, function (err) {
+              if (err) throw err;
+            });
+          });
+        });
+      });
+
+      describe('when multiple documents are updated', function () {
+        it('Emits the updated event with the updated docs', function (done) {          
+          d.insert([{ a: 1, b: 'foo' }, { a: 2, b: 'foo' }], function (err) {
+            if (err) throw err;
+            d.on('updated', function (docs) {
+              remove_ids(docs);
+              _.sortBy(docs, 'a').should.eql([{ a: 1, b: 'bar' }, { a: 2, b: 'bar' }]);
+              done();
+            });
+            d.update({ b: 'foo' }, { $set: { b: 'bar' } }, { multi: true }, function (err) {
+              if (err) throw err;
+            });
+          });
+        });
+      });
+
+      describe('when a document is inserted via an upsert', function () {
+        it('Emits the inserted event with the doc', function (done) {
+          d.on('inserted', function (docs) {
+            remove_ids(docs);
+            docs.should.eql([{ a: 1, b: 'bar' }])
+            done();
+          });
+          d.update({ a: 1 }, { $set: { b: 'bar' } }, { upsert: true }, function (err) {
+            if (err) throw err;
+          });
+        });
+        it('Does not emit the updated event', function (done) {
+          d.on('updated', function () {
+            throw new Error('Updated emitted');
+          });
+          d.update({ a: 1 }, { $set: { b: 'bar' } }, { upsert: true }, function (err) {
+            if (err) throw err;
+            setTimeout(done, 100);
+          });
+        });
+      });
+
+      describe('when no documents are affected', function () {
+        it('Emits no events', function (done) {          
+          d.insert([{ a: 1, b: 'foo' }, { a: 1, b: 'baz' }], function (err) {
+            d.on('updated', function () {
+              throw new Error('Updated emitted');
+            });
+            d.on('inserted', function () {
+              throw new Error('Insert emitted');
+            });
+            if (err) throw err;
+            d.update({ a: 2 }, { $set: { b: 'bar' } }, { multi: true }, function (err) {
+              if (err) throw err;
+              setTimeout(done, 100);
+            });
+          });
+        });
+      });
+
+      describe('when the update fails', function () {
+        it('Emits no events', function (done) {
+          d.ensureIndex({ fieldName: 'b', unique: true }, function (err) {
+            if (err) throw err;
+          });
+          d.insert([{ a: 1, b: 'foo' }, { a: 2, b: 'bar' }], function (err, doc) {
+            if (err) throw err;
+            d.on('inserted', function (docs) {
+              throw new Error('Inserted emitted');
+            });
+            d.on('updated', function (docs) {
+              throw new Error('Updated emitted');
+            });
+            d.update({}, { $set: { b: 'foo' }}, { multi: true }, function (err, doc) {
+              setTimeout(done, 100);
+            });
+          });
+        });
+      });
+    });
+
+    
+
   });   // ==== End of 'Update' ==== //
 
 
@@ -1388,6 +1538,57 @@ describe('Database', function () {
           });
         });
       });
+    });
+
+    describe('Events', function () {
+
+      describe('when a document is removed', function () {
+        it('emits the removed event with the doc', function (done) {
+          d.on('removed', function (docs) {
+            remove_ids(docs);
+            docs.should.eql([{ a: 1, b: 'foo' }]);
+            done();
+          });
+          d.insert({ a: 1, b: 'foo' }, function (err) {
+            if (err) throw err;
+            d.remove({ a: 1 }, {}, function (err) {
+              if (err) throw err;
+            });
+          });
+        });
+      });
+
+      describe('when multiple documents are removed', function () {
+        it('emits the removed event with the docs', function (done) {
+          d.on('removed', function (docs) {
+            remove_ids(docs);                      
+            _.sortBy(docs, 'a').should.eql([{ a: 1, b: 'foo' }, { a: 2, b: 'foo' }]);
+            done();
+          });
+          d.insert([{ a: 1, b: 'foo' }, { a: 2, b: 'foo' }], function (err) {
+            if (err) throw err;            
+            d.remove({ b: 'foo' }, { multi:true }, function (err) {
+              if (err) throw err;              
+            });
+          });
+        });
+      });
+
+      describe('when no documents are removed', function () {
+        it('does not emit the removed event', function (done) {
+          d.on('removed', function (docs) {
+            throw new Error('Removed emitted');
+          });
+          d.insert({ a: 1, b: 'foo' }, function (err) {
+            if (err) throw err;            
+            d.remove({ a: 2 }, {}, function (err) {
+              if (err) throw err;
+              setTimeout(done, 100);
+            });
+          });
+        });
+      });
+
     });
 
   });   // ==== End of 'Remove' ==== //


### PR DESCRIPTION
I think it would be useful for the datastore to expose data change events. This is an implementation with events that get emitted whenever documents are inserted, updated or removed:

````
db.on('inserted', function(docs){
//docs is an array of documents that have just been inserted
});
db.on('updated', function(docs){
//docs is an array of documents that have just been updated
});
db.on('removed', function(docs){
//docs is an array of documents that have just been removed
});
````
For consistency `docs` is always an array, even when only a single document has been inserted/updated/removed.