### PR TITLE
Fix multiple sort criteria

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -85,12 +85,21 @@ Cursor.prototype._exec = function(callback) {
     keys = Object.keys(this._sort);
     
     // Going backwards so that the first sort is the last that gets applied
-    for (i = keys.length - 1; i >= 0; i -= 1) {
+    var criteria = [];
+    for (i = 0; i < keys.length; i++) {
       key = keys[i];
-      res.sort(function(a, b) {
-        return self._sort[key] * model.compareThings(model.getDotValue(a, key), model.getDotValue(b, key));
-      });    
+      criteria.push({ key: key, direction: self._sort[key] });
     }
+    res.sort(function(a, b) {
+      for (var i = 0; i < criteria.length; i++) {
+        var criterion = criteria[i];
+        var compare = criterion.direction * model.compareThings(model.getDotValue(a, criterion.key), model.getDotValue(b, criterion.key));
+        if (compare !== 0) {
+          return compare;
+        }
+      }
+      return 0;
+    });
     
     // Applying limit and skip
     var limit = this._limit || res.length

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -604,7 +604,50 @@ describe('Cursor', function () {
           });
         }
       ], done);    });
-  
+
+    it('Similar data, multiple consecutive sorts', function(done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            var entities = [];
+            var companies = [ 'acme', 'milkman', 'zoinks' ];
+            var id = 1;
+            for (var i = 0; i < companies.length; i++) {
+              for (var j = 5; j <= 100; j += 5) {
+                entities.push({
+                  company: companies[i],
+                  cost: j,
+                  nid: id
+                });
+                id++;
+              }
+            }
+
+            async.each(entities, function(entity, callback) {
+              d.insert(entity, function() {
+                callback();
+              });
+            }, function(err) {
+              return cb();
+            });
+
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ company: 1, cost: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(60);
+            
+            for (var i = 0; i < docs.length; i++) {
+              docs[i].nid.should.equal(i+1);
+            };
+            return cb();
+          });
+        }
+      ], done);    });
+
   });   // ===== End of 'Sorting' =====
   
 });


### PR DESCRIPTION
With larger datasets (not browser vs node), sorting by multiple criteria was incorrect. Now, instead of sorting the array multiple times, multiple criteria are considered in a single pass.

I've added a test that used a sufficient amount of data to consistently fail under the old sort routine.

Closes #158.
Closes #143.
