### PR TITLE
Fix the nextTick(cb) causing event loop starvation

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -22,7 +22,11 @@ function Executor () {
     // Always tell the queue task is complete. Execute callback if any was given.
     if (typeof lastArg === 'function') {
       callback = function () {
-        process.nextTick(cb);
+        if (typeof setImmediate === 'function') {
+           setImmediate(cb);
+        } else {
+          process.nextTick(cb);
+        }
         lastArg.apply(null, arguments);
       };
 

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -74,7 +74,22 @@ function testRightOrder (d, done) {
   });
 }  
   
-  
+
+
+// Note:  The following test does not have any assertion because it
+// is meant to address the deprecation warning:
+// (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
+// see
+var testEventLoopStarvation = function(d, done){
+   var times = 1001;
+   var i = 0;
+   while ( i <times) {
+      i++;
+     d.find({"bogus": "search"}, function (err, docs) {
+     });
+   }
+   done();
+ };
 
 describe('Executor', function () {
 
@@ -112,6 +127,10 @@ describe('Executor', function () {
     
     it('Operations are executed in the right order', function(done) {
       testRightOrder(d, done);
+    });
+
+    it('Does not starve event loop and raise warning when more than 1000 callbacks are in queue', function(done){
+      testEventLoopStarvation(d, done);
     });
   
   });   // ==== End of 'With persistent database' ====


### PR DESCRIPTION
If you run more than 1000 lookups (like processing a big directory of
files), you will get lots of warnings from node.  Solution is to use
setImmediate(cb) instead.

Unfortunately, I could not figure out how to assert that a warning does not occur, but if you run the test I added without the fix, you will see several warnings (at least in windows with node 10.26
