### PR TITLE
Fix for strange Date behavior in Node Webkit

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -5,9 +5,7 @@
  * Querying, update
  */
 
-var dateToJSON = function () { return { $$date: this.getTime() }; }
-  , originalDateToJSON = Date.prototype.toJSON
-  , util = require('util')
+var util = require('util')
   , _ = require('underscore')
   , modifierFunctions = {}
   , lastStepModifierFunctions = {}
@@ -66,21 +64,20 @@ function checkObject (obj) {
  */
 function serialize (obj) {
   var res;
-
-  // Keep track of the fact that this is a Date object
-  Date.prototype.toJSON = dateToJSON;
-
+  
   res = JSON.stringify(obj, function (k, v) {
     checkKey(k, v);
+    
+    if (v === undefined) { return undefined; }
+    if (v === null) { return null; }
 
-    if (typeof v === undefined) { return null; }
-    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || v === null) { return v; }
+    // Hackish way of checking if object is Date (this way it works between execution contexts in node-webkit).
+    // We can't use value directly because for dates it is already string in this function (date.toJSON was already called),
+    // fortunately "this" is bound here to object which is owner of the key.
+    if (typeof this[k].getTime === 'function') { return { $$date: this[k].getTime() }; }
 
     return v;
   });
-
-  // Return Date to its original state
-  Date.prototype.toJSON = originalDateToJSON;
 
   return res;
 }


### PR DESCRIPTION
This is fix for https://github.com/louischatriot/nedb/issues/145

The issue was caused by the fact that node-webkit is actually two JS runtimes merged together (node.js and browser), and both of them have its own primitive types. More on this: https://github.com/rogerwang/node-webkit/wiki/Differences-of-JavaScript-contexts

To fix this issue I had to remove references to `Date.prototype`, because this is different object for node context, and for webkit context (the custom `toJSON` for serializing dates applied only in node context). If Date is constructed in webkit context, and then passed to node context it has different prorotype chain.

Fix is a little hackish but safe, since database is not intended to store functions, name collision with something what has method `getTime` and is not a date at the same time is highly unlikely.
