### PR TITLE
Stream functionality and MongoDB cursor resolution parity

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -3,6 +3,7 @@
  */
 var model = require('./model')
   , _ = require('underscore')
+  , events = require('events')
   ;
 
 
@@ -178,8 +179,24 @@ Cursor.prototype._exec = function(callback) {
 Cursor.prototype.exec = function () {
   this.db.executor.push({ this: this, fn: this._exec, arguments: arguments });
 };
+Cursor.prototype.toArray = Cursor.prototype.exec;
 
+Cursor.prototype.stream = function() {
+  var emitter = new events.EventEmitter();
 
+  this.exec(function(err, res) {
+    if ( err ) {
+      emitter.emit('error', err);
+      return;
+    }
+    _.forEach( res, function(item) {
+      emitter.emit('data', item);
+    } );
+    emitter.emit('end');
+  });
+
+  return emitter;
+};
 
 // Interface
 module.exports = Cursor;

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -146,6 +146,34 @@ describe('Cursor', function () {
       });
     });
 
+    it('With toArray', function (done) {
+      var cursor = new Cursor(d);
+      cursor.limit(4).skip(1);
+      cursor.toArray(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(4);
+        // No way to predict which results are returned of course ...
+        done();
+      });
+    });
+
+    it('With stream', function (done) {
+      var cursor = new Cursor(d);
+      cursor.limit(4).skip(1);
+      var stream = cursor.stream();
+      stream.on('error', function (err) {
+        assert.ok(false, 'An error occurred.');
+      });
+      var data = [];
+      stream.on('data', function(item) {
+        data.push(item);
+      });
+      stream.on('end', function() {
+        data.length.should.equal(4);
+        done();
+      });
+    });
+
   });   // ===== End of 'Without sorting' =====
 
 


### PR DESCRIPTION
Great work on this library, thanks for what you do!

The APIs for creating and modifying a cursor are equivalent in NeDB and MongoDB, in both you can execute `db.find({}).limit(4).skip(2)` and get the desired result.

However, when resolving the cursor and returning the underlying elements the APIs diverge.  In NeDB you run `cursor.exec( function(err, res) {} )` whereas in MongoDB (to achieve the same result) you would execute `cursor.toArray(function(err, res) {} )` or create a stream with `cursor.stream()` and listen for stream events.  See [this article from the mongo docs](http://mongodb.github.io/node-mongodb-native/api-articles/nodekoarticle1.html#time-to-query) for a good overview.

`cursor.exec` should be deprecated in favor of (or aliased to) the Mongo-compatible cursor resolution.  Additionally, a cursor stream interface should be supported.

A basic implementation of this change is included in this pull request.  This PR supports api parity but a full implementation of the feature should introduce streaming at a lower level so the driver doesn't need to hold the entire result set in memory.