### PR TITLE
Emit events on changes.

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -7,6 +7,7 @@ var customUtils = require('./customUtils')
   , _ = require('underscore')
   , Persistence = require('./persistence')
   , Cursor = require('./cursor')
+  , EventEmitter = require('wolfy87-eventemitter')
   ;
 
 
@@ -66,6 +67,9 @@ function Datastore (options) {
   if (this.autoload) { this.loadDatabase(options.onload || function (err) {
     if (err) { throw err; }
   }); }
+
+  // Initialize the event emitter. TODO: make this optional via a constructor option.
+  this.emitter = new EventEmitter();
 }
 
 
@@ -611,8 +615,12 @@ Datastore.prototype.remove = function () {
   this.executor.push({ this: this, fn: this._remove, arguments: arguments });
 };
 
-
-
+/**
+ * Return the event emitter for listening to database changes
+ */
+Datastore.prototype.changes = function () {
+  return this.emitter;
+};
 
 
 

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -25,6 +25,9 @@ var customUtils = require('./customUtils')
 function Datastore (options) {
   var filename;
 
+  // Initialize the event emitter. TODO: make this optional via a constructor option.
+  this.emitter = new EventEmitter();
+
   // Retrocompatibility with v0.6 and before
   if (typeof options === 'string') {
     filename = options;
@@ -67,9 +70,6 @@ function Datastore (options) {
   if (this.autoload) { this.loadDatabase(options.onload || function (err) {
     if (err) { throw err; }
   }); }
-
-  // Initialize the event emitter. TODO: make this optional via a constructor option.
-  this.emitter = new EventEmitter();
 }
 
 
@@ -286,7 +286,7 @@ Datastore.prototype.getCandidates = function (query) {
  */
 Datastore.prototype._insert = function (newDoc, cb) {
   var callback = cb || function () {}
-    ;
+    , self = this;
 
   try {
     this._insertInCache(newDoc);
@@ -296,6 +296,7 @@ Datastore.prototype._insert = function (newDoc, cb) {
 
   this.persistence.persistNewState(util.isArray(newDoc) ? newDoc : [newDoc], function (err) {
     if (err) { return callback(err); }
+    self.emitter.emit('inserted', newDoc);
     return callback(null, newDoc);
   });
 };
@@ -563,6 +564,11 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
 	// Update the datafile
     self.persistence.persistNewState(_.pluck(modifications, 'newDoc'), function (err) {
       if (err) { return callback(err); }
+
+      _.map(modifications, function(modification) {
+        self.emitter.emit('updated', modification.oldDoc, modification.newDoc);
+      });
+
       return callback(null, numReplaced);
     });
   }
@@ -608,6 +614,11 @@ Datastore.prototype._remove = function (query, options, cb) {
 
   self.persistence.persistNewState(removedDocs, function (err) {
     if (err) { return callback(err); }
+
+    _.map(removedDocs, function (removedDoc) { 
+      self.emitter.emit('removed', removedDoc);
+    });
+
     return callback(null, numRemoved);
   });
 };
@@ -621,7 +632,5 @@ Datastore.prototype.remove = function () {
 Datastore.prototype.changes = function () {
   return this.emitter;
 };
-
-
 
 module.exports = Datastore;

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -7,7 +7,7 @@ var customUtils = require('./customUtils')
   , _ = require('underscore')
   , Persistence = require('./persistence')
   , Cursor = require('./cursor')
-  , EventEmitter = require('wolfy87-eventemitter')
+  , events = require('events')
   ;
 
 
@@ -631,7 +631,7 @@ Datastore.prototype.remove = function () {
  * Return the event emitter for listening to database changes
  */
 Datastore.prototype.changes = function () {
-  return this.emitter || (this.emitter = new EventEmitter());
+  return this.emitter || (this.emitter = new events.EventEmitter());
 };
 
 module.exports = Datastore;

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -25,9 +25,6 @@ var customUtils = require('./customUtils')
 function Datastore (options) {
   var filename;
 
-  // Initialize the event emitter. TODO: make this optional via a constructor option.
-  this.emitter = new EventEmitter();
-
   // Retrocompatibility with v0.6 and before
   if (typeof options === 'string') {
     filename = options;
@@ -296,7 +293,7 @@ Datastore.prototype._insert = function (newDoc, cb) {
 
   this.persistence.persistNewState(util.isArray(newDoc) ? newDoc : [newDoc], function (err) {
     if (err) { return callback(err); }
-    self.emitter.emit('inserted', newDoc);
+    if (self.emitter) self.emitter.emit('inserted', newDoc);
     return callback(null, newDoc);
   });
 };
@@ -565,9 +562,11 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
     self.persistence.persistNewState(_.pluck(modifications, 'newDoc'), function (err) {
       if (err) { return callback(err); }
 
-      _.map(modifications, function(modification) {
-        self.emitter.emit('updated', modification.oldDoc, modification.newDoc);
-      });
+      if (self.emitter) {
+        _.map(modifications, function(modification) {
+          self.emitter.emit('updated', modification.oldDoc, modification.newDoc);
+        });
+      }
 
       return callback(null, numReplaced);
     });
@@ -615,9 +614,11 @@ Datastore.prototype._remove = function (query, options, cb) {
   self.persistence.persistNewState(removedDocs, function (err) {
     if (err) { return callback(err); }
 
-    _.map(removedDocs, function (removedDoc) { 
-      self.emitter.emit('removed', removedDoc);
-    });
+    if (self.emitter) {
+      _.map(removedDocs, function (removedDoc) { 
+        self.emitter.emit('removed', removedDoc);
+      });
+    }
 
     return callback(null, numRemoved);
   });
@@ -630,7 +631,7 @@ Datastore.prototype.remove = function () {
  * Return the event emitter for listening to database changes
  */
 Datastore.prototype.changes = function () {
-  return this.emitter;
+  return this.emitter || (this.emitter = new EventEmitter());
 };
 
 module.exports = Datastore;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "async": "0.2.10",
     "underscore": "~1.4.4",
     "binary-search-tree": "0.2.4",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "wolfy87-eventemitter": "*"
   },
   "devDependencies": {
     "chai": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "async": "0.2.10",
     "underscore": "~1.4.4",
     "binary-search-tree": "0.2.4",
-    "mkdirp": "~0.3.5",
-    "wolfy87-eventemitter": "*"
+    "mkdirp": "~0.3.5"
   },
   "devDependencies": {
     "chai": "1.0.x",

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -60,9 +60,8 @@ describe('Database', function () {
       it('Emits an \'inserted\' event on insert', function (done) {
         var testDoc = { 'message': _.random(1000) };
 
-        d.changes().once('inserted', function (err, doc) {
-          assert.isNull(err);
-          doc.message.should.equal(testDoc.message);
+        d.changes().once('inserted', function (insertedDoc) {
+          insertedDoc.message.should.equal(testDoc.message);
           done();
         });
 
@@ -72,17 +71,15 @@ describe('Database', function () {
       });
 
       it('Emits a \'removed\' event on remove', function (done) {
-        var testDoc = { 'message': _.random(1000) };
-
-        d.changes().once('removed', function (err, doc) {
+        d.insert({ 'message': _.random(1000) }, function(err, testDoc) {
           assert.isNull(err);
-          doc.message.should.equal(testDoc.message);
-          done();
-        });
 
-        d.insert(testDoc, function (err, insertedDoc) {
-          assert.isNull(err);
-          d.remove(insertedDoc, function (err, removedDoc) {
+          d.changes().once('removed', function (removedDoc) {
+            removedDoc._id.should.equal(testDoc._id);
+            done();
+          });
+
+          d.remove(testDoc, function (err, removedDoc) {
             assert.isNull(err);
           });
         });
@@ -92,8 +89,7 @@ describe('Database', function () {
         var testDoc = { 'message': _.random(1000) };
         var updatedMessage = testDoc.message + _.random(1000);
 
-        d.changes().once('updated', function (err, originalDoc, updatedDoc) {
-          assert.isNull(err);
+        d.changes().once('updated', function (originalDoc, updatedDoc) {
           originalDoc.message.should.equal(testDoc.message);
           updatedDoc.message.should.equal(updatedMessage);
           done();

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -53,6 +53,63 @@ describe('Database', function () {
     dbef.inMemoryOnly.should.equal(true);
   });
 
+  describe('Events', function () {
+
+    describe('Changes', function () {
+
+      it('Emits an \'inserted\' event on insert', function (done) {
+        var testDoc = { 'message': _.random(1000) };
+
+        d.changes().once('inserted', function (err, doc) {
+          assert.isNull(err);
+          doc.message.should.equal(testDoc.message);
+          done();
+        });
+
+        d.insert(testDoc, function (err, insertedDoc) {
+          assert.isNull(err);
+        });
+      });
+
+      it('Emits a \'removed\' event on remove', function (done) {
+        var testDoc = { 'message': _.random(1000) };
+
+        d.changes().once('removed', function (err, doc) {
+          assert.isNull(err);
+          doc.message.should.equal(testDoc.message);
+          done();
+        });
+
+        d.insert(testDoc, function (err, insertedDoc) {
+          assert.isNull(err);
+          d.remove(insertedDoc, function (err, removedDoc) {
+            assert.isNull(err);
+          });
+        });
+      });
+
+      it('Emits an \'updated\' event on update', function (done) {
+        var testDoc = { 'message': _.random(1000) };
+        var updatedMessage = testDoc.message + _.random(1000);
+
+        d.changes().once('updated', function (err, originalDoc, updatedDoc) {
+          assert.isNull(err);
+          originalDoc.message.should.equal(testDoc.message);
+          updatedDoc.message.should.equal(updatedMessage);
+          done();
+        });
+
+        d.insert(testDoc, function (err, insertedDoc) {
+          assert.isNull(err);
+          d.update(insertedDoc, { 'message': updatedMessage }, function (err, updatedDoc) {
+            assert.isNull(err);
+          });
+        });
+      });
+    });
+  });
+
+
   describe('Autoloading', function () {
   
     it('Can autoload a database and query it right away', function (done) {


### PR DESCRIPTION
This PR implements `Datastore` events on insert, update, and remove operations just before the callback to each operation. 

Similar to #175 , my use case is synchronization - but just emitting these events probably isn't enough. The next step is storing changes as documents, for querying, a `since` parameter, etc. I'm not sure I need that right away, though.

Taking suggestions for further test cases, too.