### PR TITLE
add browser field for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
     "test": "./node_modules/.bin/mocha --reporter spec --timeout 10000"
   },
   "main": "index",
+  "browser": {
+    "main": "lib/datastore.js",
+    "./lib/customUtils.js": "./browser-version/browser-specific/lib/customUtils.js",
+    "./lib/storage.js": "./browser-version/browser-specific/lib/storage.js"
+  },
   "licence": "MIT"
 }


### PR DESCRIPTION
When nedb is required by browserify it will load the server version.

These settings will fix that.

see: https://github.com/substack/node-browserify#browser-field