### PR TITLE
When upsert results in an update, upserted document is undefined in c…

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -559,7 +559,7 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
 	// Update the datafile
     self.persistence.persistNewState(_.pluck(modifications, 'newDoc'), function (err) {
       if (err) { return callback(err); }
-      return callback(null, numReplaced);
+      return callback(null, numReplaced, modifiedDoc);
     });
   }
   ]);


### PR DESCRIPTION
…allback

This happens because normal update call does not send back the document with the callback.

`upsert` is defined when a new object is inserted but not when an object is updated. For example:
```
db.update({ ... }, { ... }, { upsert: true }, function (err, numReplaced, upsert) {
 // upsert is undefined here if we updated, not inserted
});
```
In the callback, it's useful to get access to the _id of the updated object.