### PR TITLE
Bump mkdirp to fix --use-strict error. Fixes #172.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "0.2.10",
     "underscore": "~1.4.4",
     "binary-search-tree": "0.2.4",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.5.1"
   },
   "devDependencies": {
     "chai": "1.0.x",


### PR DESCRIPTION
I ran the tests before and after, both had 1 out of 271 fail.