### PR TITLE
Use an ES5 compatible syntax for octal numbers

### DIFF
--- a/test_lac/loadAndCrash.test.js
+++ b/test_lac/loadAndCrash.test.js
@@ -79,9 +79,9 @@ fs.writeFile = function(path, data, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
   if (!options || typeof options === 'function') {
-    options = { encoding: 'utf8', mode: 0o666, flag: 'w' };
+    options = { encoding: 'utf8', mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
   } else if (typeof options === 'string') {
-    options = { encoding: options, mode: 0o666, flag: 'w' };
+    options = { encoding: options, mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
   } else if (typeof options !== 'object') {
     throwOptionsError(options);
   }


### PR DESCRIPTION
I run tests with Node v0.10 and v0.12 as well. I know that these versions aren't supported anymore, but many projects still use them.
This little change makes the tests run in these versions of Node.