### PR TITLE
Implement a Time-To-Live (TTL) Indexing feature a la MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ To create an index, use `datastore.ensureIndex(options, cb)`, where callback is 
 * **fieldName** (required): name of the field to index. Use the dot notation to index a field in a nested document.
 * **unique** (optional, defaults to `false`): enforce field uniqueness. Note that a unique index will raise an error if you try to index two documents for which the field is not defined.
 * **sparse** (optional, defaults to `false`): don't index documents for which the field is not defined. Use this option along with "unique" if you want to accept multiple documents for which it is not defined.
+* **expireAfterSeconds** (optional, defaults to `null`): Time-To-Live (TTL) indexes expire documents after the specified number of seconds has passed since the indexed field value; i.e. the expiration threshold is the indexed field's `Date` value plus the specified number of seconds. Accepted values must be positive numbers between `0` (inclusive) and `Infinity` (exclusive). Based on [MongoDB's Time-To-Live (TTL) indexing concept](https://docs.mongodb.org/manual/core/index-ttl/).
 
 Note: the `_id` is automatically indexed with a unique constraint, no need to call `ensureIndex` on it.
 
@@ -560,6 +561,17 @@ db.ensureIndex({ fieldName: 'somefield', unique: true }, function (err) {
 db.ensureIndex({ fieldName: 'somefield', unique: true, sparse: true }, function (err) {
 });
 
+// Using an expiring index with a built-in Time-To-Live (TTL) based on creation
+db.ensureIndex({ fieldName: 'createdAt', expireAfterSeconds: 90 }, function(err) {
+  // Documents that include a Date value in the `createdAt` field will
+  // automatically expire 90 seconds after they were created
+})
+
+// Using an expiring index with a built-in Time-To-Live (TTL) based on modification
+db.ensureIndex({ fieldName: 'updatedAt', expireAfterSeconds: 600 }, function(err) {
+  // Documents that include a Date value in the `updatedAt` field will
+  // automatically expire 10 minutes (600 seconds) after they were last modified
+})
 
 // Format of the error message when the unique constraint is not met
 db.insert({ somefield: 'nedb' }, function (err) {

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -106,6 +106,7 @@ Datastore.prototype.resetIndexes = function (newData) {
  * @param {String} options.fieldName
  * @param {Boolean} options.unique
  * @param {Boolean} options.sparse
+ * @param {Number} options.expireAfterSeconds
  * @param {Function} cb Optional callback, signature: err
  */
 Datastore.prototype.ensureIndex = function (options, cb) {

--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -20,8 +20,32 @@ function projectForUnique (elt) {
   if (typeof elt === 'boolean') { return '$boolean' + elt; }
   if (typeof elt === 'number') { return '$number' + elt; }
   if (util.isArray(elt)) { return '$date' + elt.getTime(); }
-  
+
   return elt;   // Arrays and objects, will check for pointer equality
+}
+
+/**
+ * Filter out [and remove] any documents with an expired indexed field
+ */
+function filterExpiredDocuments (docs) {
+  var res, now
+    , self = this
+    , maxAge = self.expireAfterSeconds
+    , fieldName = self.fieldName;
+
+  if (maxAge != null && util.isArray(docs)) {
+    now = Date.now();
+    res = docs.filter(function (doc) {
+      var key = model.getDotValue(doc, fieldName);
+      if (util.isDate(key) && (key.getTime() + (maxAge * 1000)) <= now) {
+        self.remove(doc);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  return res || docs;
 }
 
 
@@ -32,11 +56,19 @@ function projectForUnique (elt) {
  * @param {String} options.fieldName On which field should the index apply (can use dot notation to index on sub fields)
  * @param {Boolean} options.unique Optional, enforce a unique constraint (default: false)
  * @param {Boolean} options.sparse Optional, allow a sparse index (we can have documents for which fieldName is undefined) (default: false)
+ * @param {Number} options.expireAfterSeconds Optional, expire indexed documents after a maximum age (in seconds) after the Date value of the property specified by fieldName (default: null)
  */
 function Index (options) {
+  var maxAge = options.expireAfterSeconds;
+
   this.fieldName = options.fieldName;
   this.unique = options.unique || false;
   this.sparse = options.sparse || false;
+  this.expireAfterSeconds = null;
+
+  if ( typeof maxAge === 'number' && maxAge >= 0 && maxAge !== Infinity ) {
+    this.expireAfterSeconds = maxAge;
+  }
 
   this.treeOptions = { unique: this.unique, compareKeys: model.compareThings, checkValueEquality: checkValueEquality };
 
@@ -230,28 +262,21 @@ Index.prototype.revertUpdate = function (oldDoc, newDoc) {
 };
 
 
-// Append all elements in toAppend to array
-function append (array, toAppend) {
-  var i;
-
-  for (i = 0; i < toAppend.length; i += 1) {
-    array.push(toAppend[i]);
-  }
-}
-
-
 /**
  * Get all documents in index whose key match value (if it is a Thing) or one of the elements of value (if it is an array of Things)
  * @param {Thing} value Value to match the key against
  * @return {Array of documents}
  */
 Index.prototype.getMatching = function (value) {
-  var self = this;
+  var _res, res
+    , self = this
+    ;
 
   if (!util.isArray(value)) {
-    return this.tree.search(value);
+    res = self.tree.search(value);
   } else {
-    var _res = {}, res = [];
+    _res = {};
+    res = [];
 
     value.forEach(function (v) {
       self.getMatching(v).forEach(function (doc) {
@@ -262,9 +287,12 @@ Index.prototype.getMatching = function (value) {
     Object.keys(_res).forEach(function (_id) {
       res.push(_res[_id]);
     });
-
-    return res;
   }
+
+  // Filter out any documents whose indexed field has expired
+  res = filterExpiredDocuments.call(self, res);
+
+  return res;
 };
 
 
@@ -275,7 +303,12 @@ Index.prototype.getMatching = function (value) {
  * @return {Array of documents}
  */
 Index.prototype.getBetweenBounds = function (query) {
-  return this.tree.betweenBounds(query);
+  var res = this.tree.betweenBounds(query);
+
+  // Filter out any documents whose indexed field has expired
+  res = filterExpiredDocuments.call(this, res);
+
+  return res;
 };
 
 
@@ -293,6 +326,9 @@ Index.prototype.getAll = function () {
       res.push(node.data[i]);
     }
   });
+
+  // Filter out any documents whose indexed field has expired
+  res = filterExpiredDocuments.call(this, res);
 
   return res;
 };

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1677,6 +1677,7 @@ describe('Database', function () {
             d.indexes.z.fieldName.should.equal('z');
             d.indexes.z.unique.should.equal(false);
             d.indexes.z.sparse.should.equal(false);
+            assert.isNull(d.indexes.z.expireAfterSeconds);
             d.indexes.z.tree.getNumberOfKeys().should.equal(3);
             d.indexes.z.tree.search('1')[0].should.equal(d.getAllData()[0]);
             d.indexes.z.tree.search('2')[0].should.equal(d.getAllData()[1]);


### PR DESCRIPTION
Fixes #346

_FIRST DRAFT!_

**TODO:**
 - [ ] Filter or remove expired documents when retrieved via any index, not just via the index with the expiration built-in
 - [ ] If only filtering expired documents (above), filter or remove expired documents when compacting