### PR TITLE
Implement exact array matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ db.find({ planet: { $regex: /ar/, $nin: ['Jupiter', 'Earth'] } }, function (err,
 
 #### Array fields
 When a field in a document is an array, NeDB first tries to see if there is an array-specific comparison function (for now there is only `$size`) being used
-and tries it first. If there isn't, the query is treated as a query on every element and there is a match if at least one element matches.
+and tries it first. If there isn't, and the query value is an array, then an exact match is performed (note this is order-sensitive). Otherwise the query is treated as a query on every element and there is a match if at least one element matches.
 
 ```javascript
 // Using an array-specific comparison function
@@ -293,6 +293,11 @@ db.find({ satellites: { $lt: 'Amos' } }, function (err, docs) {
 // This also works with the $in and $nin operator
 db.find({ satellites: { $in: ['Moon', 'Deimos'] } }, function (err, docs) {
   // docs contains Mars (the Earth document is not complete!)
+});
+
+// If the query is an array, matching it means exactly matching the array
+db.find({ satellites: ['Phobos', 'Deimos'] }, function (err, docs) {
+  // docs contains Mars. Docs would have been empty if query had been { satellites: ['Deimos', 'Phobos'] }
 });
 ```
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -484,9 +484,10 @@ function areThingsEqual (a, b) {
   // Dates
   if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime(); }
 
-  // Arrays (no match since arrays are used as a $in)
+  // Arrays (only proceed if both values are arrays so they can be exactly compared - otherwise no match since arrays are used as a $in)
   // undefined (no match since they mean field doesn't exist and can't be serialized)
-  if (util.isArray(a) || util.isArray(b) || a === undefined || b === undefined) { return false; }
+  var isBothArrays = (util.isArray(a) && util.isArray(b));
+  if (!isBothArrays && (util.isArray(a) || util.isArray(b) || a === undefined || b === undefined)) { return false; }
 
   // General objects (check for deep equality)
   // a and b should be objects at this point
@@ -705,8 +706,14 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
 
   // Check if the value is an array if we don't force a treatment as value
   if (util.isArray(objValue) && !treatObjAsValue) {
+
+    // Check if the query value is an array and perform an exact match
+    if (util.isArray(queryValue)) {
+      return matchQueryPart(obj, queryKey, queryValue, true);
+    }
+
     // Check if we are using an array-specific comparison function
-    if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
+    else if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
       keys = Object.keys(queryValue);
       for (i = 0; i < keys.length; i += 1) {
         if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true); }
@@ -722,7 +729,7 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
 
   // queryValue is an actual object. Determine whether it contains comparison operators
   // or only normal fields. Mixed objects are not allowed
-  if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
+  if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue) && !util.isArray(queryValue)) {
     keys = Object.keys(queryValue);
     firstChars = _.map(keys, function (item) { return item[0]; });
     dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; });

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -683,6 +683,32 @@ describe('Database', function () {
       });
     });
 
+    it('Array fields match if the queried array matches exactly', function (done) {
+      d.insert({ fruits: ['apple', 'banana'] }, function (err, doc1) {
+        d.insert({ fruits: [] }, function (err, doc2) {
+          d.insert({ fruits: ['banana', 'apple'] }, function (err, doc3) {
+            d.find({ fruits: ['apple', 'banana'] }, function (err, docs) {
+              assert.isNull(err);
+              docs.length.should.equal(1);
+              assert.equal(docs[0]._id, doc1._id);
+
+              d.find({ fruits: [] }, function (err, docs) {
+                assert.isNull(err);
+                docs.length.should.equal(1);
+                assert.equal(docs[0]._id, doc2._id);
+
+                d.find({ fruits: [''] }, function (err, docs) {
+                  assert.isNull(err);
+                  docs.length.should.equal(0);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
     it('Returns an error if the query is not well formed', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.find({ $or: { hello: 'world' } }, function (err, docs) {

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -687,20 +687,22 @@ describe('Database', function () {
       d.insert({ fruits: ['apple', 'banana'] }, function (err, doc1) {
         d.insert({ fruits: [] }, function (err, doc2) {
           d.insert({ fruits: ['banana', 'apple'] }, function (err, doc3) {
-            d.find({ fruits: ['apple', 'banana'] }, function (err, docs) {
-              assert.isNull(err);
-              docs.length.should.equal(1);
-              assert.equal(docs[0]._id, doc1._id);
-
-              d.find({ fruits: [] }, function (err, docs) {
+            d.insert({ fruits: ['apple', 'banana', 'coconut'] }, function (err, doc4) {
+              d.find({ fruits: ['apple', 'banana'] }, function (err, docs) {
                 assert.isNull(err);
                 docs.length.should.equal(1);
-                assert.equal(docs[0]._id, doc2._id);
+                assert.equal(docs[0]._id, doc1._id);
 
-                d.find({ fruits: [''] }, function (err, docs) {
+                d.find({ fruits: [] }, function (err, docs) {
                   assert.isNull(err);
-                  docs.length.should.equal(0);
-                  done();
+                  docs.length.should.equal(1);
+                  assert.equal(docs[0]._id, doc2._id);
+
+                  d.find({ fruits: [''] }, function (err, docs) {
+                    assert.isNull(err);
+                    docs.length.should.equal(0);
+                    done();
+                  });
                 });
               });
             });


### PR DESCRIPTION
Fixes #348

Allow the exact matching of an array by providing an array as the query value.

```js
// If the query is an array, matching it means exactly matching the array
db.find({ satellites: ['Phobos', 'Deimos'] }, function (err, docs) {
  // docs contains Mars. Docs would have been empty if query had been { satellites: ['Deimos', 'Phobos'] }
});
```