### PR TITLE
Fix a bug with the new EventEmitter inheritance

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -77,7 +77,7 @@ function Datastore (options) {
   }); }
 }
 
-util.inherits(Datastore, require('events'));
+util.inherits(Datastore, require('events').EventEmitter);
 
 
 /**


### PR DESCRIPTION
See https://travis-ci.org/lukasbestle/newdb/jobs/103116844. The build failed for Node 0.10.
This fixes it by using a syntax that is supported in all supported Node versions, including v0.10.

PS: I discovered this bug only because I let Travis CI run all releases of my fork NewDB in all supported Node versions (I think you should too).