### PR TITLE
remove mkdirp dependency

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -8,8 +8,8 @@
  */
 
 var fs = require('fs')
-  , mkdirp = require('mkdirp')
   , async = require('async')
+  , child_process = require('child_process')
   , path = require('path')
   , storage = {}
   ;
@@ -20,7 +20,47 @@ storage.writeFile = fs.writeFile;
 storage.unlink = fs.unlink;
 storage.appendFile = fs.appendFile;
 storage.readFile = fs.readFile;
-storage.mkdirp = mkdirp;
+
+/**
+ * simple, portable mkdirp code using fs.exists and child_process.spawn
+ */
+storage.mkdirp = function (dir, callback) {
+  var callbacked, callbackOnce;
+  callbackOnce = function (error) {
+  /**
+   * this function will call the callback only once
+   */
+      if (callbacked) {
+          return;
+      }
+      callbacked = true;
+      callback(error && new Error('mkdirp failed to create directory ' + dir));
+  };
+  // for performance reasons,
+  // we will only spawn the mkdir process if the dir does not already exist
+  fs.exists(dir, function (exists) {
+      // note there are no checks to verify if dir is actually a directory
+      // (versus a file or a link)
+      if (exists) {
+          callbackOnce();
+          return;
+      }
+      // spawn mkdirp child process
+      child_process.spawn(
+          'mkdir',
+          process.platform === 'win32'
+              // windows mkdir implicity has the '-p' option
+              ? [dir]
+              : ['-p', dir],
+          { stdio: ['ignore', 1, 2] }
+      )
+        .on('close', callbackOnce)
+        .on('disconnect', callbackOnce)
+        .on('error', callbackOnce)
+        .on('exit', callbackOnce);
+  });
+};
+
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "async": "0.2.10",
     "binary-search-tree": "0.2.5",
     "localforage": "^1.3.0",
-    "mkdirp": "~0.5.1",
     "underscore": "~1.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
the reasoning to remove dependencies from nedb is to eventually have it be a single standalone script that can run on both nodejs and browser (while still having small file size) (e.g. https://github.com/kaizhu256/node-swagger-lite/blob/be688f38c0b3d370470708125bbc600784341e39/lib.nedb.js)

```
kaizhu@minime2:~/src/nedb$ npm test

> nedb@1.8.0 test /Users/kaizhu/src/nedb
> mocha --reporter spec --timeout 10000

(node) child_process: options.customFds option is deprecated. Use options.stdio instead.


  Cursor
    Without sorting
      ✓ Without query, an empty query or a simple query and no skip or limit 
      ✓ With an empty collection 
      ✓ With a limit 
      ✓ With a skip 
      ✓ With a limit and a skip and method chaining 
    Sorting of the results
      ✓ Using one sort 
      ✓ Sorting strings with custom string comparison function 
      ✓ With an empty collection 
      ✓ Ability to chain sorting and exec 
      ✓ Using limit and sort 
      ✓ Using a limit higher than total number of docs shouldnt cause an error 
      ✓ Using limit and skip with sort 
      ✓ Using too big a limit and a skip with sort 
      ✓ Using too big a skip with sort should return no result 
      ✓ Sorting strings 
      ✓ Sorting nested fields with dates 
      ✓ Sorting when some fields are undefined 
      ✓ Sorting when all fields are undefined 
      ✓ Multiple consecutive sorts 
      ✓ Similar data, multiple consecutive sorts 
    Projections
      ✓ Takes all results if no projection or empty object given 
      ✓ Can take only the expected fields 
      ✓ Can omit only the expected fields 
      ✓ Cannot use both modes except for _id 
      ✓ Projections on embedded documents - omit type 
      ✓ Projections on embedded documents - pick type 

  customUtils
    uid
      ✓ Generates a string of the expected length 
      ✓ Generated uids should not be the same 

  Database
    ✓ Constructor compatibility with v0.6- 
    Autoloading
      ✓ Can autoload a database and query it right away 
      ✓ Throws if autoload fails 
    Insert
      ✓ Able to insert a document in the database, setting an _id if none provided, and retrieve it even after a reload 
      ✓ Can insert multiple documents in the database 
      ✓ Can insert and get back from DB complex objects with all primitive and secondary types 
      ✓ If an object returned from the DB is modified and refetched, the original value should be found 
      ✓ Cannot insert a doc that has a field beginning with a $ sign 
      ✓ If an _id is already given when we insert a document, use that instead of generating a random one 
      ✓ Modifying the insertedDoc after an insert doesnt change the copy saved in the database 
      ✓ Can insert an array of documents at once 
      ✓ If a bulk insert violates a constraint, all changes are rolled back 
      ✓ If timestampData option is set, a createdAt field is added and persisted 
      ✓ If timestampData option not set, don't create a createdAt and a updatedAt field 
      ✓ If timestampData is set but createdAt is specified by user, don't change it 
      ✓ If timestampData is set but updatedAt is specified by user, don't change it 
      ✓ Can insert a doc with id 0 
      ✓ If the callback throws an uncaught exception, do not catch it inside findOne, this is userspace concern 
    #getCandidates
      ✓ Can use an index to get docs with a basic match 
      ✓ Can use an index to get docs with a $in match 
      ✓ If no index can be used, return the whole database 
      ✓ Can use indexes for comparison matches 
      ✓ Can set a TTL index that expires documents (222ms)
      ✓ TTL indexes can expire multiple documents and only what needs to be expired (319ms)
      ✓ Document where indexed field is absent or not a date are ignored (209ms)
    Find
      ✓ Can find all documents if an empty query is used 
      ✓ Can find all documents matching a basic query 
      ✓ Can find one document matching a basic query and return null if none is found 
      ✓ Can find dates and objects (non JS-native types) 
      ✓ Can use dot-notation to query subfields 
      ✓ Array fields match if any element matches 
      ✓ Returns an error if the query is not well formed 
      ✓ Changing the documents returned by find or findOne do not change the database state 
      ✓ Can use sort, skip and limit if the callback is not passed to find but to exec 
      ✓ Can use sort and skip if the callback is not passed to findOne but to exec 
      ✓ Can use projections in find, normal or cursor way 
      ✓ Can use projections in findOne, normal or cursor way 
    Count
      ✓ Count all documents if an empty query is used 
      ✓ Count all documents matching a basic query 
      ✓ Array fields match if any element matches 
      ✓ Returns an error if the query is not well formed 
    Update
      ✓ If the query doesn't match anything, database is not modified 
      ✓ If timestampData option is set, update the updatedAt field (109ms)
      ✓ Can update multiple documents matching the query 
      ✓ Can update only one document matching the query 
      ✓ Cannot perform update if the update query is not either registered-modifiers-only or copy-only, or contain badly formatted fields 
      ✓ Can update documents using multiple modifiers 
      ✓ Can upsert a document even with modifiers 
      ✓ When using modifiers, the only way to update subdocs is with the dot-notation 
      ✓ Returns an error if the query is not well formed 
      ✓ If an error is thrown by a modifier, the database state is not changed 
      ✓ Cant change the _id of a document 
      ✓ Non-multi updates are persistent 
      ✓ Multi updates are persistent 
      ✓ Can update without the options arg (will use defaults then) 
      ✓ If a multi update fails on one document, previous updates should be rolled back 
      ✓ If an index constraint is violated by an update, all changes should be rolled back 
      ✓ If options.returnUpdatedDocs is true, return all matched docs 
      ✓ createdAt property is unchanged and updatedAt correct after an update, even a complete document replacement (48ms)
      Upserts
        ✓ Can perform upserts if needed 
        ✓ If the update query is a normal object with no modifiers, it is the doc that will be upserted 
        ✓ If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 1 
        ✓ If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 2 
        ✓ Performing upsert with badly formatted fields yields a standard error not an exception 
      Callback signature
        ✓ Regular update, multi false 
        ✓ Regular update, multi true 
        ✓ Upsert 
    Remove
      ✓ Can remove multiple documents 
      ✓ Remove can be called multiple times in parallel and everything that needs to be removed will be 
      ✓ Returns an error if the query is not well formed 
      ✓ Non-multi removes are persistent 
      ✓ Multi removes are persistent 
      ✓ Can remove without the options arg (will use defaults then) 
    Using indexes
      ✓ Results of getMatching should never contain duplicates 
      ensureIndex and index initialization in database loading
        ✓ ensureIndex can be called right after a loadDatabase and be initialized and filled correctly 
        ✓ ensureIndex can be called twice on the same field, the second call will ahve no effect 
        ✓ ensureIndex can be called after the data set was modified and the index still be correct 
        ✓ ensureIndex can be called before a loadDatabase and still be initialized and filled correctly 
        ✓ Can initialize multiple indexes on a database load 
        ✓ If a unique constraint is not respected, database loading will not work and no data will be inserted 
        ✓ If a unique constraint is not respected, ensureIndex will return an error and not create an index 
        ✓ Can remove an index 
      Indexing newly inserted documents
        ✓ Newly inserted documents are indexed 
        ✓ If multiple indexes are defined, the document is inserted in all of them 
        ✓ Can insert two docs at the same key for a non unique index 
        ✓ If the index has a unique constraint, an error is thrown if it is violated and the data is not modified 
        ✓ If an index has a unique constraint, other indexes cannot be modified when it raises an error 
        ✓ Unique indexes prevent you from inserting two docs where the field is undefined except if theyre sparse 
        ✓ Insertion still works as before with indexing 
        ✓ All indexes point to the same data as the main index on _id 
        ✓ If a unique constraint is violated, no index is changed, including the main one 
      Updating indexes upon document update
        ✓ Updating docs still works as before with indexing 
        ✓ Indexes get updated when a document (or multiple documents) is updated 
        ✓ If a simple update violates a contraint, all changes are rolled back and an error is thrown 
        ✓ If a multi update violates a contraint, all changes are rolled back and an error is thrown 
      Updating indexes upon document remove
        ✓ Removing docs still works as before with indexing 
        ✓ Indexes get updated when a document (or multiple documents) is removed 
      Persisting indexes
        ✓ Indexes are persisted to a separate file and recreated upon reload 
        ✓ Indexes are persisted with their options and recreated even if some db operation happen between loads 
        ✓ Indexes can also be removed and the remove persisted 

  Executor
    With persistent database
      ✓ A throw in a callback doesnt prevent execution of next operations 
      ✓ A falsy callback doesnt prevent execution of next operations 
      ✓ Operations are executed in the right order 
      ✓ Does not starve event loop and raise warning when more than 1000 callbacks are in queue 
      ✓ Works in the right order even with no supplied callback 
    With non persistent database
      ✓ A throw in a callback doesnt prevent execution of next operations 
      ✓ A falsy callback doesnt prevent execution of next operations 
      ✓ Operations are executed in the right order 
      ✓ Works in the right order even with no supplied callback 

  Indexes
    ✓ Get all elements in the index 
    Insertion
      ✓ Can insert pointers to documents in the index correctly when they have the field 
      ✓ Inserting twice for the same fieldName in a unique index will result in an error thrown 
      ✓ Inserting twice for a fieldName the docs dont have with a unique index results in an error thrown 
      ✓ Inserting twice for a fieldName the docs dont have with a unique and sparse index will not throw, since the docs will be non indexed 
      ✓ Works with dot notation 
      ✓ Can insert an array of documents 
      ✓ When inserting an array of elements, if an error is thrown all inserts need to be rolled back 
      Array fields
        ✓ Inserts one entry per array element in the index 
        ✓ Inserts one entry per array element in the index, type-checked 
        ✓ Inserts one entry per unique array element in the index, the unique constraint only holds across documents 
        ✓ The unique constraint holds across documents 
        ✓ When removing a document, remove it from the index at all unique array elements 
        ✓ If a unique constraint is violated when inserting an array key, roll back all inserts before the key 
    Removal
      ✓ Can remove pointers from the index, even when multiple documents have the same key 
      ✓ If we have a sparse index, removing a non indexed doc has no effect 
      ✓ Works with dot notation 
      ✓ Can remove an array of documents 
    Update
      ✓ Can update a document whose key did or didnt change 
      ✓ If a simple update violates a unique constraint, changes are rolled back and an error thrown 
      ✓ Can update an array of documents 
      ✓ If a unique constraint is violated during an array-update, all changes are rolled back and an error thrown 
      ✓ If an update doesnt change a document, the unique constraint is not violated 
      ✓ Can revert simple and batch updates 
    Get matching documents
      ✓ Get all documents where fieldName is equal to the given value, or an empty array if no match 
      ✓ Can get all documents for a given key in a unique index 
      ✓ Can get all documents for which a field is undefined 
      ✓ Can get all documents for which a field is null 
      ✓ Can get all documents for a given key in a sparse index, but not unindexed docs (= field undefined) 
      ✓ Can get all documents whose key is in an array of keys 
      ✓ Can get all documents whose key is between certain bounds 
    Resetting
      ✓ Can reset an index without any new data, the index will be empty afterwards 
      ✓ Can reset an index and initialize it with one document 
      ✓ Can reset an index and initialize it with an array of documents 

  Model
    Serialization, deserialization
      ✓ Can serialize and deserialize strings 
      ✓ Can serialize and deserialize booleans 
      ✓ Can serialize and deserialize numbers 
      ✓ Can serialize and deserialize null 
      ✓ undefined fields are removed when serialized 
      ✓ Can serialize and deserialize a date 
      ✓ Can serialize and deserialize sub objects 
      ✓ Can serialize and deserialize sub arrays 
      ✓ Reject field names beginning with a $ sign or containing a dot, except the four edge cases 
      ✓ Can serialize string fields with a new line without breaking the DB 
      ✓ Can accept objects whose keys are numbers 
    Object checking
      ✓ Field names beginning with a $ sign are forbidden 
      ✓ Field names cannot contain a . 
      ✓ Properties with a null value dont trigger an error 
      ✓ Can check if an object is a primitive or not 
    Deep copying
      ✓ Should be able to deep copy any serializable model 
      ✓ Should deep copy the contents of an array 
      ✓ Without the strictKeys option, everything gets deep copied 
      ✓ With the strictKeys option, only valid keys gets deep copied 
    Modifying documents
      ✓ Queries not containing any modifier just replace the document by the contents of the query but keep its _id 
      ✓ Throw an error if trying to change the _id field in a copy-type modification 
      ✓ Throw an error if trying to use modify in a mixed copy+modify way 
      ✓ Throw an error if trying to use an inexistent modifier 
      ✓ Throw an error if a modifier is used with a non-object argument 
      $set modifier
        ✓ Can change already set fields without modfifying the underlying object 
        ✓ Creates fields to set if they dont exist yet 
        ✓ Can set sub-fields and create them if necessary 
        ✓ Doesn't replace a falsy field by an object when recursively following dot notation 
      $unset modifier
        ✓ Can delete a field, not throwing an error if the field doesnt exist 
        ✓ Can unset sub-fields and entire nested documents 
        ✓ When unsetting nested fields, should not create an empty parent to nested field 
      $inc modifier
        ✓ Throw an error if you try to use it with a non-number or on a non number field 
        ✓ Can increment number fields or create and initialize them if needed 
        ✓ Works recursively 
      $push modifier
        ✓ Can push an element to the end of an array 
        ✓ Can push an element to a non-existent field and will create the array 
        ✓ Can push on nested fields 
        ✓ Throw if we try to push to a non-array 
        ✓ Can use the $each modifier to add multiple values to an array at once 
        ✓ Can use the $slice modifier to limit the number of array elements 
      $addToSet modifier
        ✓ Can add an element to a set 
        ✓ Can add an element to a non-existent set and will create the array 
        ✓ Throw if we try to addToSet to a non-array 
        ✓ Use deep-equality to check whether we can add a value to a set 
        ✓ Can use the $each modifier to add multiple values to a set at once 
      $pop modifier
        ✓ Throw if called on a non array, a non defined field or a non integer 
        ✓ Can remove the first and last element of an array 
      $pull modifier
        ✓ Can remove an element from a set 
        ✓ Can remove multiple matching elements 
        ✓ Throw if we try to pull from a non-array 
        ✓ Use deep-equality to check whether we can remove a value from a set 
        ✓ Can use any kind of nedb query with $pull 
      $max modifier
        ✓ Will set the field to the updated value if value is greater than current one, without modifying the original object 
        ✓ Will not update the field if new value is smaller than current one 
        ✓ Will create the field if it does not exist 
        ✓ Works on embedded documents 
      $min modifier
        ✓ Will set the field to the updated value if value is smaller than current one, without modifying the original object 
        ✓ Will not update the field if new value is greater than current one 
        ✓ Will create the field if it does not exist 
        ✓ Works on embedded documents 
    Comparing things
      ✓ undefined is the smallest 
      ✓ Then null 
      ✓ Then numbers 
      ✓ Then strings 
      ✓ Then booleans 
      ✓ Then dates 
      ✓ Then arrays 
      ✓ And finally objects 
      ✓ Can specify custom string comparison function 
    Querying
      Comparing things
        ✓ Two things of different types cannot be equal, two identical native things are equal 
        ✓ Can test native types null undefined string number boolean date equality 
        ✓ If one side is an array or undefined, comparison fails 
        ✓ Can test objects equality 
      Getting a fields value in dot notation
        ✓ Return first-level and nested values 
        ✓ Return undefined if the field cannot be found in the object 
        ✓ Can navigate inside arrays with dot notation, and return the array of values in that case 
        ✓ Can get a single value out of an array using its index 
      Field equality
        ✓ Can find documents with simple fields 
        ✓ Can find documents with the dot-notation 
        ✓ Cannot find undefined 
        ✓ Nested objects are deep-equality matched and not treated as sub-queries 
        ✓ Can match for field equality inside an array with the dot notation 
      Regular expression matching
        ✓ Matching a non-string to a regular expression always yields false 
        ✓ Can match strings using basic querying 
        ✓ Can match strings using the $regex operator 
        ✓ Will throw if $regex operator is used with a non regex value 
        ✓ Can use the $regex operator in cunjunction with other operators 
        ✓ Can use dot-notation 
      $lt
        ✓ Cannot compare a field to an object, an array, null or a boolean, it will return false 
        ✓ Can compare numbers, with or without dot notation 
        ✓ Can compare strings, with or without dot notation 
        ✓ If field is an array field, a match means a match on at least one element 
        ✓ Works with dates too 
      Other comparison operators: $lte, $gt, $gte, $ne, $in, $exists
        ✓ $lte 
        ✓ $gt 
        ✓ $gte 
        ✓ $ne 
        ✓ $in 
        ✓ $nin 
        ✓ $exists 
      Comparing on arrays
        ✓ Can perform a direct array match 
        ✓ Can query on the size of an array field 
        ✓ $size operator works with empty arrays 
        ✓ Should throw an error if a query operator is used without comparing to an integer 
        ✓ Using $size operator on a non-array field should prevent match but not throw 
        ✓ Can use $size several times in the same matcher 
        ✓ Can query array documents with multiple simultaneous conditions 
        ✓ $elemMatch operator works with empty arrays 
        ✓ Can use more complex comparisons inside nested query documents 
      Logical operators $or, $and, $not
        ✓ Any of the subqueries should match for an $or to match 
        ✓ All of the subqueries should match for an $and to match 
        ✓ Subquery should not match for a $not to match 
        ✓ Logical operators are all top-level, only other logical operators can be above 
        ✓ Logical operators can be combined as long as they are on top of the decision tree 
        ✓ Should throw an error if a logical operator is used without an array or if an unknown logical operator is used 
      Comparison operator $where
        ✓ Function should match and not match correctly 
        ✓ Should throw an error if the $where function is not, in fact, a function 
        ✓ Should throw an error if the $where function returns a non-boolean 
        ✓ Should be able to do the complex matching it must be used for 
      Array fields
        ✓ Field equality 
        ✓ With one comparison operator 
        ✓ Works with arrays that are in subdocuments 
        ✓ Can query inside arrays thanks to dot notation 
        ✓ Can query for a specific element inside arrays thanks to dot notation 
        ✓ A single array-specific operator and the query is treated as array specific 
        ✓ Can mix queries on array fields and non array filds with array specific operators 

  Persistence
    ✓ Every line represents a document 
    ✓ Badly formatted lines have no impact on the treated data 
    ✓ Well formatted lines that have no _id are not included in the data 
    ✓ If two lines concern the same doc (= same _id), the last one is the good version 
    ✓ If a doc contains $$deleted: true, that means we need to remove it from the data 
    ✓ If a doc contains $$deleted: true, no error is thrown if the doc wasnt in the list before 
    ✓ If a doc contains $$indexCreated, no error is thrown during treatRawData and we can get the index options 
    ✓ Compact database on load 
    ✓ Calling loadDatabase after the data was modified doesnt change its contents 
    ✓ Calling loadDatabase after the datafile was removed will reset the database 
    ✓ Calling loadDatabase after the datafile was modified loads the new data 
    ✓ When treating raw data, refuse to proceed if too much data is corrupt, to avoid data loss 
    ✓ Can listen to compaction events 
    Serialization hooks
      ✓ Declaring only one hook will throw an exception to prevent data loss 
      ✓ Declaring two hooks that are not reverse of one another will cause an exception to prevent data loss 
      ✓ A serialization hook can be used to transform data before writing new state to disk 
      ✓ Use serialization hook when persisting cached database or compacting 
      ✓ Deserialization hook is correctly used when loading data 
    Prevent dataloss when persisting data
      ✓ Creating a datastore with in memory as true and a bad filename wont cause an error 
      ✓ Creating a persistent datastore with a bad filename will cause an error 
      ✓ If no file exists, ensureDatafileIntegrity creates an empty datafile 
      ✓ If only datafile exists, ensureDatafileIntegrity will use it 
      ✓ If temp datafile exists and datafile doesnt, ensureDatafileIntegrity will use it (cannot happen except upon first use) 
      ✓ If both temp and current datafiles exist, ensureDatafileIntegrity will use the datafile, as it means that the write of the temp file failed 
      ✓ persistCachedDatabase should update the contents of the datafile and leave a clean state 
      ✓ After a persistCachedDatabase, there should be no temp or old filename 
      ✓ persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile 
      ✓ persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile 
      ✓ Persistence works as expected when everything goes fine 
      ✓ If system crashes during a loadDatabase, the former version is not lost (231ms)
      ✓ Cannot cause EMFILE errors by opening too many file descriptors (307ms)
    ensureFileDoesntExist
      ✓ Doesnt do anything if file already doesnt exist 
      ✓ Deletes file if it exists 


  ✔ 330 tests complete (3.141 seconds)
```