### PR TITLE
Fixed datastore.js typo

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -314,7 +314,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     docs.forEach(function (doc) {
       var valid = true;
       ttlIndexesFieldNames.forEach(function (i) {
-        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
+        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
           valid = false;
         }
       });


### PR DESCRIPTION
Fix datastore.js developer typo issue, after 'if' statement he puts 'special character' instead of 'space'


**this issue prevent from using NeBD in es6 & typescript.
after this small change it works 