### PR TITLE
allow callback parameter for compactDatafile() - just like all other executor commands

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -146,7 +146,7 @@ Persistence.prototype.persistCachedDatabase = function (cb) {
  * Queue a rewrite of the datafile
  */
 Persistence.prototype.compactDatafile = function () {
-  this.db.executor.push({ this: this, fn: this.persistCachedDatabase, arguments: [] });
+  this.db.executor.push({ this: this, fn: this.persistCachedDatabase, arguments: arguments });
 };
 
 


### PR DESCRIPTION
This patch makes it possible to call compactDatafile() and get notified once the task has completed:

```
db.persistence.compactDatafile(function() {
  console.log("Datafile compacted.");
});
```

All other executor commands accept a callback function, I honestly see no reason why `compactDatafile()` should be an exception.

Thanks.