### PR TITLE
Pause and resume2

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -97,6 +97,9 @@ Datastore.prototype.loadDatabase = function () {
  */ 
 Datastore.prototype.pause = function (cb) {
 
+  if (this.isPaused())
+    throw new Error("Already paused");
+
   var cbAsync = function() { setTimeout(cb, 1); };
 
   // queue a NOP command, so that the pause() callback is called once paused. Use async timer to make sure (sync) _pause() is called earlier. 

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -92,10 +92,15 @@ Datastore.prototype.loadDatabase = function () {
 
 
 /**
- * Pauses the database, queueing all writes until resume() is called
+ * Pauses the database, queueing all writes until resume() is called.
+ * cb() is called once the database executor has been blocked 
  */ 
 Datastore.prototype.pause = function (cb) {
-  this.executor.push({ this: this, fn: this._pause, arguments: arguments });
+  // queue a NOP command, so that the pause() callback is called once paused 
+  this.executor.push({ this: this, fn: function() { cb(); }, arguments: arguments });
+  
+  // then queue the pause command itself, which will block the executor
+  this.executor.push({ this: this, fn: this._pause, arguments: [null] });
 }
 
 

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -96,8 +96,8 @@ Datastore.prototype.loadDatabase = function () {
  * cb() is called once the database executor has been blocked 
  */ 
 Datastore.prototype.pause = function (cb) {
-  // queue a NOP command, so that the pause() callback is called once paused 
-  this.executor.push({ this: this, fn: function() { cb(); }, arguments: arguments });
+  // queue a NOP command, so that the pause() callback is called once paused. Use async timer to make sure (sync) _pause() is called earlier. 
+  this.executor.push({ this: this, fn: function() { setTimeout(cb, 1); }, arguments: arguments });
   
   // then queue the pause command itself, which will block the executor
   this.executor.push({ this: this, fn: this._pause, arguments: [null] });

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -28,6 +28,8 @@ var customUtils = require('./customUtils')
  */
 function Datastore (options) {
   var filename;
+  
+  this.resumeCb = null;
 
   // Retrocompatibility with v0.6 and before
   if (typeof options === 'string') {
@@ -87,6 +89,27 @@ util.inherits(Datastore, require('events').EventEmitter);
 Datastore.prototype.loadDatabase = function () {
   this.executor.push({ this: this.persistence, fn: this.persistence.loadDatabase, arguments: arguments }, true);
 };
+
+
+/**
+ * Pauses the database, queueing all writes until resume() is called
+ */ 
+Datastore.prototype.pause = function (cb) {
+  this.executor.push({ this: this, fn: this._pause, arguments: arguments });
+}
+
+
+/**
+ * Resumes writes when pause() had been called before.
+ */ 
+Datastore.prototype.resume = function () {
+  if (!this.resumeCb)
+    throw new Error("Not paused");
+    
+  var cb = this.resumeCb;
+  this.resumeCb = null;
+  cb();  
+}
 
 
 /**
@@ -355,6 +378,18 @@ Datastore.prototype._insert = function (newDoc, cb) {
     if (err) { return callback(err); }
     return callback(null, model.deepCopy(preparedDoc));
   });
+};
+
+
+/**
+ * Pause the executor until resume() is called
+ * @param {Function} cb Optional callback
+ *
+ * @api private Use Datastore.pause which has the same signature
+ */
+Datastore.prototype._pause = function (cb) {
+  // cb() will be called in resume(), so this will block the executor until resume() is being called  
+  this.resumeCb = cb;
 };
 
 /**

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -121,6 +121,14 @@ Datastore.prototype.resume = function () {
 
 
 /**
+ * Returns TRUE when the database is currently paused.
+ */ 
+Datastore.prototype.isPaused = function () {
+  return !!this.resumeCb;  
+}
+
+
+/**
  * Get an array of all the data in the database
  */
 Datastore.prototype.getAllData = function () {

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -96,8 +96,11 @@ Datastore.prototype.loadDatabase = function () {
  * cb() is called once the database executor has been blocked 
  */ 
 Datastore.prototype.pause = function (cb) {
+
+  var cbAsync = function() { setTimeout(cb, 1); };
+
   // queue a NOP command, so that the pause() callback is called once paused. Use async timer to make sure (sync) _pause() is called earlier. 
-  this.executor.push({ this: this, fn: function() { setTimeout(cb, 1); }, arguments: arguments });
+  this.executor.push({ this: this, fn: function(cbQueue) { setTimeout(cbQueue, 1); }, arguments: [cbAsync] });
   
   // then queue the pause command itself, which will block the executor
   this.executor.push({ this: this, fn: this._pause, arguments: [null] });


### PR DESCRIPTION
This PR adds `pause()` and `resume()` methods to NeDB Datastore.

Granted this is a somewhat strange addition but combined with #427 this allows to pause write accesses to the storage and queue them until `resume()` is called.

A custom storage engine can make use of this to create consistent snapshots of one or more databases.

Meanwhile read-accesses to the dabase continue to return instantly and write-accesses are delayed until `resume()` has been called.

Thanks to the NeDB executor this wasn't hard to implement. :smile: 