### PR TITLE
Fix invalid character in datastore.js

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -314,7 +314,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     docs.forEach(function (doc) {
       var valid = true;
       ttlIndexesFieldNames.forEach(function (i) {
-        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
+        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
           valid = false;
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nedb",
-  "version": "1.8.0",
+  "version": "4.8.0",
   "author": {
     "name": "Louis Chatriot",
     "email": "louis.chatriot@gmail.com"


### PR DESCRIPTION
Hi there,

I am using nedb with babel and I was getting 

> datastore.js:316 Uncaught SyntaxError: Unexpected token {

due to an invalid character in line 316 after the closing ')'. 

Cheers,
Elvis
