### PR TITLE
Stream files line by line when parsing to avoid memory limits

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -11,6 +11,7 @@ var storage = require('./storage')
   , async = require('async')
   , customUtils = require('./customUtils')
   , Index = require('./indexes')
+  , byline = require('byline')
   ;
 
 
@@ -204,23 +205,25 @@ Persistence.prototype.persistNewState = function (newDocs, cb) {
 
 
 /**
- * From a database's raw data, return the corresponding
+ * From a database's raw stream, return the corresponding
  * machine understandable collection
  */
-Persistence.prototype.treatRawData = function (rawData) {
-  var data = rawData.split('\n')
-    , dataById = {}
+Persistence.prototype.treatRawStream = function (rawStream, cb) {
+  var dataById = {}
     , tdata = []
     , i
     , indexes = {}
-    , corruptItems = -1   // Last line of every data file is usually blank so not really corrupt
+    , corruptItems = 0
     ;
 
-  for (i = 0; i < data.length; i += 1) {
+  var lineStream = byline(rawStream);
+  var length = 0;
+  var that = this;
+  lineStream.on('data', function(line) {
     var doc;
 
     try {
-      doc = model.deserialize(this.beforeDeserialization(data[i]));
+      doc = model.deserialize(that.beforeDeserialization(line));
       if (doc._id) {
         if (doc.$$deleted === true) {
           delete dataById[doc._id];
@@ -235,18 +238,26 @@ Persistence.prototype.treatRawData = function (rawData) {
     } catch (e) {
       corruptItems += 1;
     }
-  }
-
-  // A bit lenient on corruption
-  if (data.length > 0 && corruptItems / data.length > this.corruptAlertThreshold) {
-    throw new Error("More than " + Math.floor(100 * this.corruptAlertThreshold) + "% of the data file is corrupt, the wrong beforeDeserialization hook may be used. Cautiously refusing to start NeDB to prevent dataloss");
-  }
-
-  Object.keys(dataById).forEach(function (k) {
-    tdata.push(dataById[k]);
+    length ++;
   });
 
-  return { data: tdata, indexes: indexes };
+  lineStream.on('end', function() {
+    // A bit lenient on corruption
+    var err;
+    if (length > 0 && corruptItems / length > that.corruptAlertThreshold) {
+      err = new Error("More than " + Math.floor(100 * that.corruptAlertThreshold) + "% of the data file is corrupt, the wrong beforeDeserialization hook may be used. Cautiously refusing to start NeDB to prevent dataloss");
+    }
+
+    Object.keys(dataById).forEach(function (k) {
+      tdata.push(dataById[k]);
+    });
+
+    cb(err, { data: tdata, indexes: indexes })
+  });
+
+  lineStream.on('error', function(err) {
+    cb(err);
+  });
 };
 
 
@@ -274,14 +285,9 @@ Persistence.prototype.loadDatabase = function (cb) {
     function (cb) {
       Persistence.ensureDirectoryExists(path.dirname(self.filename), function (err) {
         storage.ensureDatafileIntegrity(self.filename, function (err) {
-          storage.readFile(self.filename, 'utf8', function (err, rawData) {
+          var fileStream = storage.readFileStream(self.filename, {encoding : 'utf8'});
+          self.treatRawStream(fileStream, function(err, treatedData) {
             if (err) { return cb(err); }
-
-            try {
-              var treatedData = self.treatRawData(rawData);
-            } catch (e) {
-              return cb(e);
-            }
 
             // Recreate all indexes in the datafile
             Object.keys(treatedData.indexes).forEach(function (key) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -20,6 +20,7 @@ storage.writeFile = fs.writeFile;
 storage.unlink = fs.unlink;
 storage.appendFile = fs.appendFile;
 storage.readFile = fs.readFile;
+storage.readFileStream = fs.createReadStream;
 storage.mkdirp = mkdirp;
 
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "0.2.10",
     "binary-search-tree": "0.2.5",
+    "byline": "5.0.0",
     "localforage": "^1.3.0",
     "mkdirp": "~0.5.1",
     "underscore": "~1.4.4"

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -828,7 +828,7 @@ describe('Database', function () {
         });
       });
     });
-    
+
     it('Can use sort, skip and limit if the callback is not passed to find but to exec', function (done) {
       d.insert({ a: 2, hello: 'world' }, function () {
         d.insert({ a: 24, hello: 'earth' }, function () {
@@ -843,7 +843,7 @@ describe('Database', function () {
               });
             });
           });
-        });      
+        });
       });
     });
 
@@ -856,7 +856,7 @@ describe('Database', function () {
               d.findOne({}).sort({ a: 1 }).exec(function (err, doc) {
                 assert.isNull(err);
                 doc.hello.should.equal('world');
-                
+
                 // A query
                 d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).exec(function (err, doc) {
                   assert.isNull(err);
@@ -1230,13 +1230,13 @@ describe('Database', function () {
               d.find({}, function (err, docs) {
                 docs.length.should.equal(1);   // Default option for upsert is false
                 docs[0].something.should.equal("created ok");
-                
+
                 // Modifying the returned upserted document doesn't modify the database
                 newDoc.newField = true;
                 d.find({}, function (err, docs) {
                   docs[0].something.should.equal("created ok");
                   assert.isUndefined(docs[0].newField);
-                
+
                   done();
                 });
               });
@@ -1244,7 +1244,7 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('If the update query is a normal object with no modifiers, it is the doc that will be upserted', function (done) {
         d.update({ $or: [{ a: 4 }, { a: 5 }] }, { hello: 'world', bloup: 'blap' }, { upsert: true }, function (err) {
           d.find({}, function (err, docs) {
@@ -1258,7 +1258,7 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 1', function (done) {
         d.update({ $or: [{ a: 4 }, { a: 5 }] }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
           d.find({ hello: 'world' }, function (err, docs) {
@@ -1272,7 +1272,7 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 2', function (done) {
         d.update({ $or: [{ a: 4 }, { a: 5 }], cac: 'rrr' }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
           d.find({ hello: 'world' }, function (err, docs) {
@@ -1287,7 +1287,7 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('Performing upsert with badly formatted fields yields a standard error not an exception', function(done) {
         d.update({_id: '1234'}, { $set: { $$badfield: 5 }}, { upsert: true }, function(err, doc) {
           assert.isDefined(err);
@@ -1504,7 +1504,7 @@ describe('Database', function () {
         });
       });
     });
-    
+
     it('Can update without the options arg (will use defaults then)', function (done) {
       d.insert({ a:1, hello: 'world' }, function (err, doc1) {
         d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
@@ -1517,11 +1517,11 @@ describe('Database', function () {
                   , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
                   , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
                   ;
-                  
+
                 d1.a.should.equal(1);
                 d2.a.should.equal(12);
                 d3.a.should.equal(5);
-                
+
                 done();
               });
             });
@@ -1875,7 +1875,7 @@ describe('Database', function () {
         });
       });
     });
-    
+
     it('Can remove without the options arg (will use defaults then)', function (done) {
       d.insert({ a:1, hello: 'world' }, function (err, doc1) {
         d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
@@ -1888,11 +1888,11 @@ describe('Database', function () {
                   , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
                   , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
                   ;
-                  
+
                 d1.a.should.equal(1);
                 assert.isUndefined(d2);
                 d3.a.should.equal(5);
-                
+
                 done();
               });
             });
@@ -1936,33 +1936,33 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('ensureIndex can be called twice on the same field, the second call will ahve no effect', function (done) {
         Object.keys(d.indexes).length.should.equal(1);
         Object.keys(d.indexes)[0].should.equal("_id");
-      
+
         d.insert({ planet: "Earth" }, function () {
           d.insert({ planet: "Mars" }, function () {
             d.find({}, function (err, docs) {
               docs.length.should.equal(2);
-              
+
               d.ensureIndex({ fieldName: "planet" }, function (err) {
                 assert.isNull(err);
                 Object.keys(d.indexes).length.should.equal(2);
-                Object.keys(d.indexes)[0].should.equal("_id");   
-                Object.keys(d.indexes)[1].should.equal("planet");   
+                Object.keys(d.indexes)[0].should.equal("_id");
+                Object.keys(d.indexes)[1].should.equal("planet");
 
                 d.indexes.planet.getAll().length.should.equal(2);
-                
+
                 // This second call has no effect, documents don't get inserted twice in the index
                 d.ensureIndex({ fieldName: "planet" }, function (err) {
                   assert.isNull(err);
                   Object.keys(d.indexes).length.should.equal(2);
-                  Object.keys(d.indexes)[0].should.equal("_id");   
-                  Object.keys(d.indexes)[1].should.equal("planet");   
+                  Object.keys(d.indexes)[0].should.equal("_id");
+                  Object.keys(d.indexes)[1].should.equal("planet");
 
-                  d.indexes.planet.getAll().length.should.equal(2);                
-                  
+                  d.indexes.planet.getAll().length.should.equal(2);
+
                   done();
                 });
               });
@@ -2141,19 +2141,19 @@ describe('Database', function () {
           });
         });
       });
-      
+
       it('Can remove an index', function (done) {
         d.ensureIndex({ fieldName: 'e' }, function (err) {
           assert.isNull(err);
-          
+
           Object.keys(d.indexes).length.should.equal(2);
           assert.isNotNull(d.indexes.e);
-          
+
           d.removeIndex("e", function (err) {
             assert.isNull(err);
             Object.keys(d.indexes).length.should.equal(1);
-            assert.isUndefined(d.indexes.e); 
- 
+            assert.isUndefined(d.indexes.e);
+
             done();
           });
         });
@@ -2161,7 +2161,7 @@ describe('Database', function () {
 
     });   // ==== End of 'ensureIndex and index initialization in database loading' ==== //
 
-    
+
     describe('Indexing newly inserted documents', function () {
 
       it('Newly inserted documents are indexed', function (done) {
@@ -2815,7 +2815,7 @@ describe('Database', function () {
                   assert.isNull(err);
                   Object.keys(db.indexes).length.should.equal(3);
                   Object.keys(db.indexes)[0].should.equal("_id");
-                  Object.keys(db.indexes)[1].should.equal("planet");  
+                  Object.keys(db.indexes)[1].should.equal("planet");
                   Object.keys(db.indexes)[2].should.equal("another");
                   db.indexes._id.getAll().length.should.equal(2);
                   db.indexes.planet.getAll().length.should.equal(2);

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -11,6 +11,7 @@ var should = require('chai').should()
   , Persistence = require('../lib/persistence')
   , storage = require('../lib/storage')
   , child_process = require('child_process')
+  , Readable = require('stream').Readable
 ;
 
 
@@ -42,108 +43,158 @@ describe('Persistence', function () {
     ], done);
   });
 
-  it('Every line represents a document', function () {
+  it('Every line represents a document', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ _id: "2", hello: 'world' }) + '\n' +
     model.serialize({ _id: "3", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(3);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
-    _.isEqual(treatedData[2], { _id: "3", nested: { today: now } }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(3);
+      _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+      _.isEqual(treatedData[2], { _id: "3", nested: { today: now } }).should.equal(true);
+      done();
+    });
   });
 
-  it('Badly formatted lines have no impact on the treated data', function () {
+  it('Badly formatted lines have no impact on the treated data', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     'garbage\n' +
     model.serialize({ _id: "3", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", nested: { today: now } }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      console.log(err);
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "3", nested: { today: now } }).should.equal(true);
+      done();
+    });
   });
 
-  it('Well formatted lines that have no _id are not included in the data', function () {
+  it('Well formatted lines that have no _id are not included in the data', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ _id: "2", hello: 'world' }) + '\n' +
     model.serialize({ nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+      done();
+    });
   });
 
-  it('If two lines concern the same doc (= same _id), the last one is the good version', function () {
+  it('If two lines concern the same doc (= same _id), the last one is the good version', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ _id: "2", hello: 'world' }) + '\n' +
     model.serialize({ _id: "1", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", nested: { today: now } }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "1", nested: { today: now } }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+      done();
+    });
   });
 
-  it('If a doc contains $$deleted: true, that means we need to remove it from the data', function () {
+  it('If a doc contains $$deleted: true, that means we need to remove it from the data', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ _id: "2", hello: 'world' }) + '\n' +
     model.serialize({ _id: "1", $$deleted: true }) + '\n' +
     model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "2", hello: 'world' }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "2", hello: 'world' }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+      done();
+    });
   });
 
-  it('If a doc contains $$deleted: true, no error is thrown if the doc wasnt in the list before', function () {
+  it('If a doc contains $$deleted: true, no error is thrown if the doc wasnt in the list before', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ _id: "2", $$deleted: true }) + '\n' +
     model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
     ;
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
+
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+      done();
+    });
   });
 
-  it('If a doc contains $$indexCreated, no error is thrown during treatRawData and we can get the index options', function () {
+  it('If a doc contains $$indexCreated, no error is thrown during treatRawData and we can get the index options', function (done) {
     var now = new Date()
       , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
     model.serialize({ $$indexCreated: { fieldName: "test", unique: true } }) + '\n' +
     model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
-      , indexes = d.persistence.treatRawData(rawData).indexes
     ;
 
-    Object.keys(indexes).length.should.equal(1);
-    assert.deepEqual(indexes.test, { fieldName: "test", unique: true });
+    var stream = new Readable();
+    stream.push(rawData);
+    stream.push(null);
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+    d.persistence.treatRawStream(stream, function (err, result) {
+      var treatedData = result.data;
+      var indexes = result.indexes;
+      Object.keys(indexes).length.should.equal(1);
+      assert.deepEqual(indexes.test, { fieldName: "test", unique: true });
+
+      treatedData.sort(function (a, b) { return a._id - b._id; });
+      treatedData.length.should.equal(2);
+      _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+      _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+      done();
+    });
   });
 
   it('Compact database on load', function (done) {
@@ -275,7 +326,6 @@ describe('Persistence', function () {
       , d
     ;
     fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
-
     // Default corruptAlertThreshold
     d = new Datastore({ filename: corruptTestFilename });
     d.loadDatabase(function (err) {


### PR DESCRIPTION
These changes allows nedb to load large databases without running into the string length limit for node by streaming the file line by line instead of trying to load it all at once.

Tested with a large randomly generated ~256MB database that will load after these changes.

I don't know what the browser-based implications here are since this does remove `Persistence.prototype.treatRawData`, but I'd be happy to help resolve them if you could point me in the right direction.