### PR TITLE
Added Datastore.findOpts(query, opts, callback)

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -495,12 +495,15 @@ Datastore.prototype.find = function (query, projection, callback) {
 
 /**
  * Same as find above, only that the second param is now an object of config objects.
- * It will never return a cursor. This keeps this nodeback function promisifyable.
+ * It will never return a cursor. This keeps this find nodeback function promisifyable.
+ *
  * @param {Object} query MongoDB-style query
  * @param {Object} opts
  * @param {Object} opts.fields MongoDB-style projection
- * @param {Object} opts.skip skip value for paging
- * @param {Object} opts.limit skip value for paging
+ * @param {Object} opts.sort MongoDB-style sort
+ * @param {Object} opts.paging
+ * @param {Number} opts.paging.skip skip value for paging
+ * @param {Number} opts.paging.limit limit value for paging
  */
 Datastore.prototype.findOpts = function (query, opts, callback) {
 
@@ -532,11 +535,19 @@ Datastore.prototype.findOpts = function (query, opts, callback) {
 
     cursor.projection(projections);
 
-    if (typeof callback === 'function' && (!opts.skip && !opts.limit)) {
-        cursor.exec(callback);
-    } else {
-        cursor.skip(opts.skip).limit(opts.limit).exec(callback)
-    }
+    //load up the cursor depending on opts
+    let rollingCursor = cursor;
+
+	if(opts.paging){
+		rollingCursor = rollingCursor.skip(opts.paging.skip).limit(opts.paging.limit);
+	}
+
+	if (opts.sort){
+		rollingCursor = rollingCursor.sort(opts.sort)
+	}
+
+	rollingCursor.exec(callback);
+
 };
 
 

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -493,6 +493,52 @@ Datastore.prototype.find = function (query, projection, callback) {
   }
 };
 
+/**
+ * Same as find above, only that the second param is now an object of config objects.
+ * It will never return a cursor. This keeps this nodeback function promisifyable.
+ * @param {Object} query MongoDB-style query
+ * @param {Object} opts
+ * @param {Object} opts.fields MongoDB-style projection
+ * @param {Object} opts.skip skip value for paging
+ * @param {Object} opts.limit skip value for paging
+ */
+Datastore.prototype.findOpts = function (query, opts, callback) {
+
+    switch (arguments.length) {
+        case 1:
+            opts = {};
+            // callback is undefined, will return a cursor
+            break;
+        case 2:
+            if (typeof opts === 'function') {
+                callback = opts;
+                opts = {};
+            }   // If not assume projection is an object and callback undefined
+            break;
+    }
+
+    var cursor = new Cursor(this, query, function(err, docs, callback) {
+        var res = [], i;
+
+        if (err) { return callback(err); }
+
+        for (i = 0; i < docs.length; i += 1) {
+            res.push(model.deepCopy(docs[i]));
+        }
+        return callback(null, res);
+    });
+
+    const projections = opts.fields||{};
+
+    cursor.projection(projections);
+
+    if (typeof callback === 'function' && (!opts.skip && !opts.limit)) {
+        cursor.exec(callback);
+    } else {
+        cursor.skip(opts.skip).limit(opts.limit).exec(callback)
+    }
+};
+
 
 /**
  * Find one document matching the query


### PR DESCRIPTION
Same as the find find above, only that the second param is now an object of config objects.
+ * It will never return a cursor. This keeps this find nodeback function promisifyable

findOpts is an extended version of the find function, where the 2nd parameter (previously just projections) is now used to pass in **fields** (aka projections), **paging**, and **sort**  values.

This function will never return a cursor and will always expect the last parameter to be a callback, keeping it auto-promisification-compliant.