### PR TITLE
Read file as Buffer, process lines as strings.

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -208,13 +208,21 @@ Persistence.prototype.persistNewState = function (newDocs, cb) {
  * machine understandable collection
  */
 Persistence.prototype.treatRawData = function (rawData) {
-  var data = rawData.split('\n')
+  var data = []
+    , buffer = rawData
     , dataById = {}
     , tdata = []
     , i
     , indexes = {}
     , corruptItems = -1   // Last line of every data file is usually blank so not really corrupt
+    , index = -1
     ;
+
+  while( (index = buffer.indexOf('\n')) > -1 ) {
+    data = data.concat(buffer.slice(0, index).toString('utf8'));
+    buffer = buffer.slice(index + 1); // 1 for the '\n' itself
+  }
+  data = data.concat(buffer.toString('utf8')); // last line; intentionally adds even if empty
 
   for (i = 0; i < data.length; i += 1) {
     var doc;
@@ -274,7 +282,7 @@ Persistence.prototype.loadDatabase = function (cb) {
     function (cb) {
       Persistence.ensureDirectoryExists(path.dirname(self.filename), function (err) {
         storage.ensureDatafileIntegrity(self.filename, function (err) {
-          storage.readFile(self.filename, 'utf8', function (err, rawData) {
+          storage.readFile(self.filename, function (err, rawData) {
             if (err) { return cb(err); }
 
             try {


### PR DESCRIPTION
Read the file as a Buffer, then process lines as strings.

This avoids/mitigates maximum string length issues in V8.

Fixes #389

(Just if helpful :-) )