### PR TITLE
Update NW.js code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,10 @@ var Datastore = require('nedb')
 // You can issue commands right away
 
 
-// Type 4: Persistent datastore for a Node Webkit app called 'nwtest'
-// For example on Linux, the datafile will be ~/.config/nwtest/nedb-data/something.db
-var Datastore = require('nedb')
-  , path = require('path')
-  , db = new Datastore({ filename: path.join(require('nw.gui').App.dataPath, 'something.db') });
+// Type 4: Persistent datastore for an NW.js app
+const path = require('path');
+const Datastore = require('nedb');
+const db = new Datastore({ filename: path.join(nw.App.dataPath, 'something.db') });
 
 
 // Of course you can create multiple datastores if you need several


### PR DESCRIPTION
NW.js is no longer called Node-Webkit. And has been using `nw` as a replacement for `require('nw.gui')` for about 3 or 4 years now.