### PR TITLE
Keep existing updated at

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -619,7 +619,12 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
             modifiedDoc = model.modify(candidates[i], updateQuery);
             if (self.timestampData) {
               modifiedDoc.createdAt = createdAt;
-              modifiedDoc.updatedAt = new Date();
+              //Update BD 2020-03-03 :
+              //Contrary to what is stated in the doc, updatedAt is always set to new Date() on document update, even if an updatedAt value is present in the request
+              // Adding the following 'if' statement changes that behaviour and keeps the request updatedAt value if present (this is necessary for synchronization mechanism)
+              if (updateQuery.$set.updatedAt === undefined) {
+                modifiedDoc.updatedAt = new Date();
+              }
             }
             modifications.push({ oldDoc: candidates[i], newDoc: modifiedDoc });
           }

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -619,9 +619,7 @@ Datastore.prototype._update = function (query, updateQuery, options, cb) {
             modifiedDoc = model.modify(candidates[i], updateQuery);
             if (self.timestampData) {
               modifiedDoc.createdAt = createdAt;
-              //Update BD 2020-03-03 :
-              //Contrary to what is stated in the doc, updatedAt is always set to new Date() on document update, even if an updatedAt value is present in the request
-              // Adding the following 'if' statement changes that behaviour and keeps the request updatedAt value if present (this is necessary for synchronization mechanism)
+              // If no updatedAt date is present, using the current time
               if (updateQuery.$set.updatedAt === undefined) {
                 modifiedDoc.updatedAt = new Date();
               }


### PR DESCRIPTION
Contrary to what is stated in the doc, updatedAt is always set to new Date() on document update, even if an updatedAt value is present in the request. I added an 'if' statement that changes that behaviour and keeps the request updatedAt value if present (this is necessary for synchronization mechanism).