### PR TITLE
Disable directory fsync on AIX

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -51,9 +51,9 @@ storage.flushToStorage = function (options, callback) {
     flags = options.isDir ? 'r' : 'r+';
   }
 
-  // Windows can't fsync (FlushFileBuffers) directories. We can live with this as it cannot cause 100% dataloss
+  // Windows/AIX can't fsync (FlushFileBuffers) directories. We can live with this as it cannot cause 100% dataloss
   // except in the very rare event of the first time database is loaded and a crash happens
-  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) { return callback(null); }
+  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64' || process.platform === 'aix')) { return callback(null); }
 
   fs.open(filename, flags, function (err, fd) {
     if (err) { return callback(err); }


### PR DESCRIPTION
Pretty self-explanatory change. Running this on IBM i (an AIX variant), I get:
```pascal
Error: Failed to flush to storage
    at /QOpenSys/pkgs/lib/nodejs12/lib/node_modules/crontab-ui/node_modules/nedb/lib/storage.js:63:19
    at FSReqCallback.oncomplete (fs.js:154:23) {
  errorOnFsync: [Error: EINVAL: invalid argument, fsync] {
    errno: -22,
    code: 'EINVAL',
    syscall: 'fsync'
  },
  errorOnClose: null
}
```
AIX needs the special case with Windows. 