### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can use NeDB as an in-memory only datastore or as a persistent datastore. On
 default string comparison which is not well adapted to non-US characters
 in particular accented letters. Native `localCompare` will most of the
 time be the right choice
-* `nodeWebkitAppName` (optional, **DEPRECATED**): if you are using NeDB from whithin a Node Webkit app, specify its name (the same one you use in the `package.json`) in this field and the `filename` will be relative to the directory Node Webkit uses to store the rest of the application's data (local storage etc.). It works on Linux, OS X and Windows. Now that you can use `require('nw.gui').App.dataPath` in Node Webkit to get the path to the data directory for your application, you should not use this option anymore and it will be removed.
+* `nodeWebkitAppName` (optional, **DEPRECATED**): if you are using NeDB from within a Node Webkit app, specify its name (the same one you use in the `package.json`) in this field and the `filename` will be relative to the directory Node Webkit uses to store the rest of the application's data (local storage etc.). It works on Linux, OS X and Windows. Now that you can use `require('nw.gui').App.dataPath` in Node Webkit to get the path to the data directory for your application, you should not use this option anymore and it will be removed.
 
 If you use a persistent datastore without the `autoload` option, you need to call `loadDatabase` manually.
 This function fetches the data from datafile and prepares the database. **Don't forget it!** If you use a
@@ -545,7 +545,7 @@ db.update({ _id: 'id6' }, { $push: { fruits: { $each: ['banana', 'orange'] } } }
   // Now the fruits array is ['apple', 'orange', 'pear', 'banana', 'orange']
 });
 
-// $slice can be used in cunjunction with $push and $each to limit the size of the resulting array.
+// $slice can be used in conjunction with $push and $each to limit the size of the resulting array.
 // A value of 0 will update the array to an empty array. A positive value n will keep only the n first elements
 // A negative value -n will keep only the last n elements.
 // If $slice is specified but not $each, $each is set to []
@@ -707,7 +707,7 @@ If you submit a pull request, thanks! There are a couple rules to follow though 
 * The pull request should be atomic, i.e. contain only one feature. If it contains more, please submit multiple pull requests. Reviewing massive, 1000 loc+ pull requests is extremely hard.
 * Likewise, if for one unique feature the pull request grows too large (more than 200 loc tests not included), please get in touch first.
 * Please stick to the current coding style. It's important that the code uses a coherent style for readability.
-* Do not include sylistic improvements ("housekeeping"). If you think one part deserves lots of housekeeping, use a separate pull request so as not to pollute the code.
+* Do not include stylistic improvements ("housekeeping"). If you think one part deserves lots of housekeeping, use a separate pull request so as not to pollute the code.
 * Don't forget tests for your new feature. Also don't forget to run the whole test suite before submitting to make sure you didn't introduce regressions.
 * Do not build the browser version in your branch, I'll take care of it once the code is merged.
 * Update the readme accordingly.

--- a/browser-version/out/nedb.js
+++ b/browser-version/out/nedb.js
@@ -1616,7 +1616,7 @@ Datastore.prototype.findOne = function (query, projection, callback) {
  *          the callback signature was (err, numAffected, updated) where updated was the updated document in case of an upsert
  *          or the array of updated documents for an update if the returnUpdatedDocs option was true. That meant that the type of
  *          affectedDocuments in a non multi update depended on whether there was an upsert or not, leaving only two ways for the
- *          user to check whether an upsert had occured: checking the type of affectedDocuments or running another find query on
+ *          user to check whether an upsert had occurred: checking the type of affectedDocuments or running another find query on
  *          the whole dataset to check its size. Both options being ugly, the breaking change was necessary.
  *
  * @api private Use Datastore.update which has the same signature
@@ -1801,7 +1801,7 @@ function Executor () {
         lastArg.apply(null, arguments);
       };
     } else if (!lastArg && task.arguments.length !== 0) {
-      // false/undefined/null supplied as callbback
+      // false/undefined/null supplied as callback
       newArguments[newArguments.length - 1] = function () { cb(); };
     } else {
       // Nothing supplied as callback
@@ -3423,7 +3423,7 @@ var process=require("__browserify_process");/*global setImmediate: false, setTim
         }
     }
 
-    //// cross-browser compatiblity functions ////
+    //// cross-browser compatibility functions ////
 
     var _each = function (arr, iterator) {
         if (arr.forEach) {

--- a/browser-version/test/chai.js
+++ b/browser-version/test/chai.js
@@ -61,13 +61,13 @@ require.helper.semVerSort = function(a, b) {
 
  * @param {String} name - module name: `user~repo`
  * @param {Boolean} returnPath - returns the canonical require path if true, 
- *                               otherwise it returns the epxorted module
+ *                               otherwise it returns the exported module
  */
 require.latest = function (name, returnPath) {
   function showError(name) {
     throw new Error('failed to find latest module of "' + name + '"');
   }
-  // only remotes with semvers, ignore local files conataining a '/'
+  // only remotes with semvers, ignore local files containing a '/'
   var versionRegexp = /(.*)~(.*)@v?(\d+\.\d+\.\d+[^\/]*)$/;
   var remoteRegexp = /(.*)~(.*)/;
   if (!remoteRegexp.test(name)) showError(name);
@@ -97,7 +97,7 @@ require.latest = function (name, returnPath) {
     return require(module);
   }
   // if the build contains more than one branch of the same module
-  // you should not use this funciton
+  // you should not use this function
   var module = otherCandidates.sort(function(a, b) {return a.name > b.name})[0].name;
   if (returnPath === true) {
     return module;

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1364,7 +1364,7 @@ describe('Database', function () {
 
     it('When using modifiers, the only way to update subdocs is with the dot-notation', function (done) {
       d.insert({ bloup: { blip: "blap", other: true } }, function () {
-        // Correct methos
+        // Correct method
         d.update({}, { $set: { "bloup.blip": "hello" } }, {}, function () {
           d.findOne({}, function (err, doc) {
             doc.bloup.blip.should.equal("hello");


### PR DESCRIPTION
There are small typos in:
- README.md
- browser-version/out/nedb.js
- browser-version/test/chai.js
- test/db.test.js

Fixes:
- Should read `within` rather than `whithin`.
- Should read `stylistic` rather than `sylistic`.
- Should read `occurred` rather than `occured`.
- Should read `method` rather than `methos`.
- Should read `function` rather than `funciton`.
- Should read `exported` rather than `epxorted`.
- Should read `containing` rather than `conataining`.
- Should read `conjunction` rather than `cunjunction`.
- Should read `compatibility` rather than `compatiblity`.
- Should read `callback` rather than `callbback`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md